### PR TITLE
Don't override safe areas for all web views

### DIFF
--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -289,6 +289,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate {
         return .cancel
     }
     
-    
-    
+    override open var safeAreaInsets: UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
 }

--- a/Sources/FronteggSwift/embedded/FronteggWebView.swift
+++ b/Sources/FronteggSwift/embedded/FronteggWebView.swift
@@ -80,8 +80,3 @@ fileprivate final class InputAccessoryHackHelper: NSObject {
     @objc var inputAccessoryView: AnyObject? { return nil }
 }
 
-extension WKWebView {
-    override open var safeAreaInsets: UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    }
-}


### PR DESCRIPTION
The implementation of FronteggWebView uses an class extension to override the safeAreaInsets and set them to zero.  This implementation override safe areas for all web views, including web views created by clients using this library.  Specifically, this includes the web view used by Ionic/Capacitor applications.  

This means that the CSS environment variables env(safe-area-inset-top), env(safe-area-inset-left), env(safe-area-inset-right), env(safe-area-inset-bottom) will alway return zero for any web view, effectively preventing clients from properly adding recommended padding around notches, etc.

This pull request changes the class extension to a regular class instance override so the zero safe area padding only applies to the FronteggWebView.