### PR TITLE
FronteggError Enum Granularity

### DIFF
--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -277,7 +277,7 @@ public class FronteggAuth: ObservableObject {
             }
             
             guard let data = responseData else {
-                completion(.failure(FronteggError.authError("Failed to authenticate with frontegg")))
+                completion(.failure(FronteggError.authError(.failedToAuthenticate)))
                 setIsLoading(false)
                 return
             }
@@ -290,7 +290,7 @@ public class FronteggAuth: ObservableObject {
                 completion(.success(user!))
             } catch {
                 logger.error("Failed to load user data: \(error.localizedDescription)")
-                completion(.failure(FronteggError.authError("Failed to load user data: \(error.localizedDescription)")))
+                completion(.failure(FronteggError.authError(.failedToLoadUserData(error.localizedDescription))))
                 setIsLoading(false)
                 return
             }
@@ -309,27 +309,26 @@ public class FronteggAuth: ObservableObject {
         
         return { callbackUrl, error in
             
-            if error != nil {
-                completion(.failure(FronteggError.authError(error!.localizedDescription)))
+            if let error {
+                completion(.failure(FronteggError.authError(.other(error))))
                 return
             }
             
             guard let url = callbackUrl else {
-                let errorMessage = "Unknown error occurred"
-                completion(.failure(FronteggError.authError(errorMessage)))
+                completion(.failure(FronteggError.authError(.unknown)))
                 return
             }
             
             
             self.logger.trace("handleHostedLoginCallback, url: \(url)")
             guard let queryItems = getQueryItems(url.absoluteString), let code = queryItems["code"] else {
-                let error = FronteggError.authError("Failed to get extract code from hostedLoginCallback url")
+                let error = FronteggError.authError(.failedToExtractCode)
                 completion(.failure(error))
                 return
             }
             
             guard let codeVerifier = CredentialManager.getCodeVerifier() else {
-                let error = FronteggError.authError("IlligalState, codeVerifier not found")
+                let error = FronteggError.authError(.codeVerifierNotFound)
                 completion(.failure(error))
                 return
             }
@@ -506,7 +505,7 @@ public class FronteggAuth: ObservableObject {
             rootVC.present(hostingController, animated: false, completion: nil)
             
         } else {
-            logger.critical(FronteggError.authError("Unable to find root viewController").localizedDescription)
+            logger.critical(FronteggError.authError(.couldNotFindRootViewController).localizedDescription)
             exit(500)
         }
     }
@@ -518,7 +517,7 @@ public class FronteggAuth: ObservableObject {
         }
         
         guard let rootVC = self.getRootVC(useAppRootVC) else {
-            logger.error(FronteggError.authError("Unable to find root viewController").localizedDescription)
+            logger.error(FronteggError.authError(.couldNotFindRootViewController).localizedDescription)
             return false;
         }
         
@@ -568,7 +567,7 @@ public class FronteggAuth: ObservableObject {
                 if let user = self.user, await self.refreshTokenIfNeeded() && completion != nil {
                     completion?(.success(user))
                 } else {
-                    completion?(.failure(FronteggError.authError("Failed to swift tenant")))
+                    completion?(.failure(FronteggError.authError(.failedToSwitchTenant)))
                 }
                 
             }

--- a/Sources/FronteggSwift/models/errors/AuthenticationError.swift
+++ b/Sources/FronteggSwift/models/errors/AuthenticationError.swift
@@ -1,0 +1,42 @@
+//
+//  AuthenticationError.swift
+//
+//
+//  Created by Nick Hagi on 17/07/2024.
+//
+
+import Foundation
+
+// MARK: - AuthenticationError
+extension FronteggError {
+    
+    public enum Authentication: LocalizedError {
+        case couldNotExchangeToken(_ message: String)
+        case failedToAuthenticate
+        case failedToLoadUserData(_ message: String)
+        case failedToExtractCode
+        case failedToSwitchTenant
+        case codeVerifierNotFound
+        case couldNotFindRootViewController
+        case unknown
+        case other(Error)
+    }
+}
+
+// MARK: - LocalizedError
+extension FronteggError.Authentication {
+
+    public var errorDescription: String? {
+        switch self {
+        case let .couldNotExchangeToken(message): message
+        case .failedToAuthenticate: "Failed to authenticate with frontegg"
+        case let .failedToLoadUserData(message): "Failed to load user data: \(message)"
+        case .failedToExtractCode: "Failed to get extract code from hostedLoginCallback url"
+        case .failedToSwitchTenant: "Failed to switch tenant"
+        case .codeVerifierNotFound: "Code verifier not found"
+        case .couldNotFindRootViewController: "Unable to find root viewController"
+        case .unknown: "Unknown error occurred"
+        case let .other(error): error.localizedDescription
+        }
+    }
+}

--- a/Sources/FronteggSwift/models/errors/ConfigurationError.swift
+++ b/Sources/FronteggSwift/models/errors/ConfigurationError.swift
@@ -1,0 +1,32 @@
+//
+//  ConfigurationError.swift
+//
+//
+//  Created by Nick Hagi on 17/07/2024.
+//
+
+import Foundation
+
+// MARK: - ConfigurationError
+extension FronteggError {
+
+    public enum Configuration: LocalizedError {
+        case missingPlist
+        case missingClientIdOrBaseURL(_ atPath: String)
+        case missingRegions
+        case invalidRegions(_ atPath: String)
+    }
+}
+
+// MARK: - LocalizedError
+extension FronteggError.Configuration {
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingPlist: "Missing Frontegg.plist file with 'clientId' and 'baseUrl' entries in main bundle!"
+        case let .missingClientIdOrBaseURL(path): "Frontegg.plist file at \(path) is missing 'clientId' and/or 'baseUrl' entries!"
+        case .missingRegions: "no regions in Frontegg.plist"
+        case let .invalidRegions(path): "Frontegg.plist file at \(path) has invalid regions data, regions must be array of (key, baseUrl, clientId)"
+        }
+    }
+}

--- a/Sources/FronteggSwift/models/errors/FronteggError.swift
+++ b/Sources/FronteggSwift/models/errors/FronteggError.swift
@@ -1,0 +1,13 @@
+//
+//  FronteggError.swift
+//
+//
+//  Created by Nick Hagi on 17/07/2024.
+//
+
+import Foundation
+
+public enum FronteggError: Error {
+    case configError(Configuration)
+    case authError(Authentication)
+}

--- a/Sources/FronteggSwift/services/Api.swift
+++ b/Sources/FronteggSwift/services/Api.swift
@@ -126,7 +126,7 @@ public class Api {
             
             return (try JSONDecoder().decode(AuthResponse.self, from: data), nil)
         }catch {
-            return (nil, FronteggError.authError(error.localizedDescription))
+            return (nil, FronteggError.authError(.couldNotExchangeToken(error.localizedDescription)))
         }
     }
     


### PR DESCRIPTION
## Overview

This PR extracts all errors thrown by the SDK into strongly typed errors whilst keeping the same messaging as the current live version of the SDK.

This approach adds support for an additional level of granularity when it comes to handling errors on the client side.

## Reasoning

The current implementation throws two types of errors (`configError` and `authError`), but the associated values of those enum cases are both Strings, which doesn't allow for disambiguation of the error message at the client level. Because of this, clients can only distinguish between `configError` and `authError`, so barring any exact string checks on the client side, it is not possible to display custom error messages for each situation.

An example of such scenario is presenting different error messages when the user cancels the authentication session versus a failed authentication error.

Another example is the localisation of the errors thrown into multiple languages on the client side.

The approach in this PR addresses both of these issues.