### PR TITLE
Decode Frontegg Plist using Decodable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,5 +29,14 @@ let package = Package(
                 // .package(url: /* package url */, from: "1.0.0"),
             ]
         ),
+        .testTarget(
+            name: "FronteggSwiftTests",
+            dependencies: [
+                "FronteggSwift"
+            ],
+            resources: [
+                .copy("MockRegions")
+            ]
+        )
     ]
 )

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -40,14 +40,13 @@ public class FronteggApp {
         self.credentialManager = CredentialManager(serviceKey: config.keychainService)
         self.bundleIdentifier = PlistHelper.bundleIdentifier()
         
-        let bridgeOptions = PlistHelper.getNativeBridgeOptions()
-        self.handleLoginWithSocialLogin = bridgeOptions["loginWithSocialLogin"] ?? true
-        self.handleLoginWithSSO = bridgeOptions["loginWithSSO"] ?? false
-        
+        self.handleLoginWithSocialLogin = config.loginWithSocialLogin
+        self.handleLoginWithSSO = config.loginWithSSO
+
         /**
          lateInit used for react-native and ionic-capacitor initialization
          */
-        if(PlistHelper.isLateInit()){
+        if config.lateInit {
             self.auth = FronteggAuth(
                 baseUrl: self.baseUrl,
                 clientId: self.clientId,
@@ -132,9 +131,11 @@ public class FronteggApp {
         
         self.auth.manualInit(baseUrl: baseUrl, clientId: cliendId, applicationId: applicationId)
     }
-    public func manualInitRegions(regions: [RegionConfig],
-                                  handleLoginWithSocialLogin: Bool = true,
-                                  handleLoginWithSSO:Bool = false) {
+    public func manualInitRegions(
+        regions: [RegionConfig],
+        handleLoginWithSocialLogin: Bool = true,
+        handleLoginWithSSO:Bool = false
+    ) {
         self.regionData = regions
         self.handleLoginWithSocialLogin = handleLoginWithSocialLogin
         self.handleLoginWithSSO = handleLoginWithSSO
@@ -144,7 +145,7 @@ public class FronteggApp {
         self.applicationId = self.auth.applicationId
     }
 
-    public func initWithRegion( regionKey:String ){
+    public func initWithRegion(regionKey: String){
         
         if self.regionData.count == 0 {
             fatalError("illegal state. Frontegg.plist does not contains regions array")

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -152,7 +152,7 @@ public class FronteggApp {
     public func initWithRegion(regionKey: String){
         
         if self.regionData.count == 0 {
-            fatalError("illegal state. Frontegg.plist does not contains regions array")
+            fatalError(FronteggError.configError(.missingRegions).localizedDescription)
         }
         
         guard let config = self.regionData.first(where: { config in
@@ -161,7 +161,7 @@ public class FronteggApp {
             let keys: String = self.regionData.map { config in
                 config.key
             }.joined(separator: ", ")
-            fatalError("invalid region key \(regionKey). available regions: \(keys)")
+            fatalError(FronteggError.configError(.invalidRegionKey(regionKey, keys)).localizedDescription)
         }
         
         CredentialManager.saveSelectedRegion(regionKey)

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -60,7 +60,7 @@ public class FronteggApp {
             return
         }
 
-        switch config {
+        switch config.payload {
         case let .multiRegion(config):
             logger.info("Regional frontegg initialization")
             self.regionData = config.regions

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -34,12 +34,16 @@ public class FronteggApp {
         do {
             config = try PlistHelper.fronteggConfig()
         } catch {
-            fatalError("Fatal Error: Could not load Frontegg Plist: \(error)")
+            fatalError(FronteggError.configError(.couldNotLoadPlist(error.localizedDescription)).localizedDescription)
         }
         self.embeddedMode = config.embeddedMode
         self.credentialManager = CredentialManager(serviceKey: config.keychainService)
-        self.bundleIdentifier = PlistHelper.bundleIdentifier()
-        
+
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+            fatalError(FronteggError.configError(.couldNotLoadPlist(Bundle.main.bundlePath)).localizedDescription)
+        }
+        self.bundleIdentifier = bundleIdentifier
+
         self.handleLoginWithSocialLogin = config.loginWithSocialLogin
         self.handleLoginWithSSO = config.loginWithSSO
 

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -38,7 +38,7 @@ public class FronteggApp {
         }
 
         guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
-            fatalError(FronteggError.configError(.couldNotLoadPlist(Bundle.main.bundlePath)).localizedDescription)
+            fatalError(FronteggError.configError(.couldNotGetBundleID(Bundle.main.bundlePath)).localizedDescription)
         }
 
         self.embeddedMode = config.embeddedMode

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -36,14 +36,14 @@ public class FronteggApp {
         } catch {
             fatalError(FronteggError.configError(.couldNotLoadPlist(error.localizedDescription)).localizedDescription)
         }
-        self.embeddedMode = config.embeddedMode
-        self.credentialManager = CredentialManager(serviceKey: config.keychainService)
 
         guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
             fatalError(FronteggError.configError(.couldNotLoadPlist(Bundle.main.bundlePath)).localizedDescription)
         }
-        self.bundleIdentifier = bundleIdentifier
 
+        self.embeddedMode = config.embeddedMode
+        self.credentialManager = CredentialManager(serviceKey: config.keychainService)
+        self.bundleIdentifier = bundleIdentifier
         self.handleLoginWithSocialLogin = config.loginWithSocialLogin
         self.handleLoginWithSSO = config.loginWithSSO
 

--- a/Sources/FronteggSwift/FronteggApp.swift
+++ b/Sources/FronteggSwift/FronteggApp.swift
@@ -32,7 +32,7 @@ public class FronteggApp {
     init() {
         let config: FronteggPlist
         do {
-            config = try PlistHelper.plist()
+            config = try PlistHelper.fronteggConfig()
         } catch {
             fatalError("Fatal Error: Could not load Frontegg Plist: \(error)")
         }

--- a/Sources/FronteggSwift/models/errors/ConfigurationError.swift
+++ b/Sources/FronteggSwift/models/errors/ConfigurationError.swift
@@ -11,6 +11,8 @@ import Foundation
 extension FronteggError {
 
     public enum Configuration: LocalizedError, Equatable {
+        case couldNotLoadPlist(_ errorDescription: String)
+        case couldNotGetBundleID(_ atPath: String)
         case missingPlist
         case missingClientIdOrBaseURL(_ atPath: String)
         case missingRegions
@@ -23,6 +25,8 @@ extension FronteggError.Configuration {
 
     public var errorDescription: String? {
         switch self {
+        case let .couldNotLoadPlist(error): "Could not load Frontegg Plist: \(error)"
+        case let .couldNotGetBundleID(path): "Could not get bundle identifier from Bundle.main (path: \(path))"
         case .missingPlist: "Missing Frontegg.plist file with 'clientId' and 'baseUrl' entries in main bundle!"
         case let .missingClientIdOrBaseURL(path): "Frontegg.plist file at \(path) is missing 'clientId' and/or 'baseUrl' entries!"
         case .missingRegions: "no regions in Frontegg.plist"

--- a/Sources/FronteggSwift/models/errors/ConfigurationError.swift
+++ b/Sources/FronteggSwift/models/errors/ConfigurationError.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - ConfigurationError
 extension FronteggError {
 
-    public enum Configuration: LocalizedError {
+    public enum Configuration: LocalizedError, Equatable {
         case missingPlist
         case missingClientIdOrBaseURL(_ atPath: String)
         case missingRegions

--- a/Sources/FronteggSwift/models/errors/ConfigurationError.swift
+++ b/Sources/FronteggSwift/models/errors/ConfigurationError.swift
@@ -17,6 +17,8 @@ extension FronteggError {
         case missingClientIdOrBaseURL(_ atPath: String)
         case missingRegions
         case invalidRegions(_ atPath: String)
+        case invalidRegionKey(_ regionKey: String, _ availableKeys: String)
+        case failedToGenerateAuthorizeURL
     }
 }
 
@@ -31,6 +33,8 @@ extension FronteggError.Configuration {
         case let .missingClientIdOrBaseURL(path): "Frontegg.plist file at \(path) is missing 'clientId' and/or 'baseUrl' entries!"
         case .missingRegions: "no regions in Frontegg.plist"
         case let .invalidRegions(path): "Frontegg.plist file at \(path) has invalid regions data, regions must be array of (key, baseUrl, clientId)"
+        case let .invalidRegionKey(regionKey, availableKeys): "invalid region key \(regionKey). available regions: \(availableKeys)"
+        case .failedToGenerateAuthorizeURL: "Failed to generate authorize url"
         }
     }
 }

--- a/Sources/FronteggSwift/models/errors/FronteggError.swift
+++ b/Sources/FronteggSwift/models/errors/FronteggError.swift
@@ -7,7 +7,14 @@
 
 import Foundation
 
-public enum FronteggError: Error {
+public enum FronteggError: LocalizedError {
     case configError(Configuration)
     case authError(Authentication)
+
+    public var errorDescription: String? {
+        switch self {
+        case .configError(let error): error.errorDescription
+        case .authError(let error): error.errorDescription
+        }
+    }
 }

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -1,0 +1,46 @@
+//
+//  FronteggPlist.swift
+//
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import Foundation
+
+enum FronteggPlist: Equatable {
+
+    case singleRegion(SingleRegionConfig)
+    case multiRegion(MultiRegionConfig)
+}
+
+// MARK: - Init
+extension FronteggPlist: Decodable {
+
+    init(from decoder: any Decoder) throws {
+        do {
+            let multiRegion = try decoder.singleValueContainer().decode(MultiRegionConfig.self)
+            self = .multiRegion(multiRegion)
+        } catch {
+            let singleRegion = try decoder.singleValueContainer().decode(SingleRegionConfig.self)
+            self = .singleRegion(singleRegion)
+        }
+    }
+}
+
+// MARK: - Helper Properties
+extension FronteggPlist {
+
+    var keychainService: String {
+        switch self {
+        case .singleRegion(let config): config.keychainService
+        case .multiRegion(let config): config.keychainService
+        }
+    }
+
+    var embeddedMode: Bool {
+        switch self {
+        case .singleRegion(let config): config.embeddedMode
+        case .multiRegion(let config): config.embeddedMode
+        }
+    }
+}

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -43,4 +43,25 @@ extension FronteggPlist {
         case .multiRegion(let config): config.embeddedMode
         }
     }
+
+    var loginWithSocialLogin: Bool {
+        switch self {
+        case .singleRegion(let config): config.loginWithSocialLogin
+        case .multiRegion(let config): config.loginWithSocialLogin
+        }
+    }
+
+    var loginWithSSO: Bool {
+        switch self {
+        case .singleRegion(let config): config.loginWithSSO
+        case .multiRegion(let config): config.loginWithSSO
+        }
+    }
+
+    var lateInit: Bool {
+        switch self {
+        case .singleRegion(let config): config.lateInit
+        case .multiRegion(let config): config.lateInit
+        }
+    }
 }

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -7,14 +7,72 @@
 
 import Foundation
 
-enum FronteggPlist: Equatable {
+struct FronteggPlist: Decodable, Equatable {
+    
+    let keychainService: String
+    let embeddedMode: Bool
+    let loginWithSocialLogin: Bool
+    let loginWithSSO: Bool
+    let lateInit: Bool
+    let payload: Payload
 
-    case singleRegion(SingleRegionConfig)
-    case multiRegion(MultiRegionConfig)
+    enum CodingKeys: CodingKey {
+        case keychainService
+        case embeddedMode
+        case loginWithSocialLogin
+        case loginWithSSO
+        case lateInit
+    }
+
+    init(
+        keychainService: String = "frontegg",
+        embeddedMode: Bool = true,
+        loginWithSocialLogin: Bool = true,
+        loginWithSSO: Bool = false,
+        lateInit: Bool = false,
+        payload: FronteggPlist.Payload
+    ) {
+        self.keychainService = keychainService
+        self.embeddedMode = embeddedMode
+        self.loginWithSocialLogin = loginWithSocialLogin
+        self.loginWithSSO = loginWithSSO
+        self.lateInit = lateInit
+        self.payload = payload
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let keychainService = try container.decodeIfPresent(String.self, forKey: .keychainService)
+        self.keychainService = keychainService ?? "frontegg"
+
+        let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
+        self.embeddedMode = embeddedMode ?? true
+
+        let socialLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSocialLogin)
+        self.loginWithSocialLogin = socialLogin ?? true
+
+        let ssoLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSSO)
+        self.loginWithSSO = ssoLogin ?? false
+
+        let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
+        self.lateInit = lateInit ?? false
+
+        self.payload = try Payload(from: decoder)
+    }
+}
+
+extension FronteggPlist {
+
+    enum Payload: Equatable {
+
+        case singleRegion(SingleRegionConfig)
+        case multiRegion(MultiRegionConfig)
+    }
 }
 
 // MARK: - Init
-extension FronteggPlist: Decodable {
+extension FronteggPlist.Payload: Decodable {
 
     init(from decoder: any Decoder) throws {
         do {
@@ -23,45 +81,6 @@ extension FronteggPlist: Decodable {
         } catch {
             let singleRegion = try decoder.singleValueContainer().decode(SingleRegionConfig.self)
             self = .singleRegion(singleRegion)
-        }
-    }
-}
-
-// MARK: - Helper Properties
-extension FronteggPlist {
-
-    var keychainService: String {
-        switch self {
-        case .singleRegion(let config): config.keychainService
-        case .multiRegion(let config): config.keychainService
-        }
-    }
-
-    var embeddedMode: Bool {
-        switch self {
-        case .singleRegion(let config): config.embeddedMode
-        case .multiRegion(let config): config.embeddedMode
-        }
-    }
-
-    var loginWithSocialLogin: Bool {
-        switch self {
-        case .singleRegion(let config): config.loginWithSocialLogin
-        case .multiRegion(let config): config.loginWithSocialLogin
-        }
-    }
-
-    var loginWithSSO: Bool {
-        switch self {
-        case .singleRegion(let config): config.loginWithSSO
-        case .multiRegion(let config): config.loginWithSSO
-        }
-    }
-
-    var lateInit: Bool {
-        switch self {
-        case .singleRegion(let config): config.lateInit
-        case .multiRegion(let config): config.lateInit
         }
     }
 }

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -14,6 +14,7 @@ struct FronteggPlist: Decodable, Equatable {
     let loginWithSocialLogin: Bool
     let loginWithSSO: Bool
     let lateInit: Bool
+    let logLevel: LogLevel
     let payload: Payload
 
     enum CodingKeys: CodingKey {
@@ -22,6 +23,7 @@ struct FronteggPlist: Decodable, Equatable {
         case loginWithSocialLogin
         case loginWithSSO
         case lateInit
+        case logLevel
     }
 
     init(
@@ -30,13 +32,15 @@ struct FronteggPlist: Decodable, Equatable {
         loginWithSocialLogin: Bool = true,
         loginWithSSO: Bool = false,
         lateInit: Bool = false,
-        payload: FronteggPlist.Payload
+        logLevel: LogLevel = .warn,
+        payload: Payload
     ) {
         self.keychainService = keychainService
         self.embeddedMode = embeddedMode
         self.loginWithSocialLogin = loginWithSocialLogin
         self.loginWithSSO = loginWithSSO
         self.lateInit = lateInit
+        self.logLevel = logLevel
         self.payload = payload
     }
 
@@ -58,6 +62,9 @@ struct FronteggPlist: Decodable, Equatable {
         let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
         self.lateInit = lateInit ?? false
 
+        let logLevel = try container.decodeIfPresent(LogLevel.self, forKey: .logLevel)
+        self.logLevel = logLevel ?? .warn
+
         self.payload = try Payload(from: decoder)
     }
 }
@@ -71,7 +78,6 @@ extension FronteggPlist {
     }
 }
 
-// MARK: - Init
 extension FronteggPlist.Payload: Decodable {
 
     init(from decoder: any Decoder) throws {
@@ -81,6 +87,33 @@ extension FronteggPlist.Payload: Decodable {
         } catch {
             let singleRegion = try decoder.singleValueContainer().decode(SingleRegionConfig.self)
             self = .singleRegion(singleRegion)
+        }
+    }
+}
+
+extension FronteggPlist {
+
+    enum LogLevel: String, Decodable {
+
+        case trace
+        case debug
+        case info
+        case warn
+        case error
+        case critical
+    }
+}
+
+extension Logger.Level {
+
+    init(with logLevel: FronteggPlist.LogLevel) {
+        switch logLevel {
+        case .trace: self = .trace
+        case .debug: self = .debug
+        case .info: self = .info
+        case .warn: self = .warning
+        case .error: self = .error
+        case .critical: self = .critical
         }
     }
 }

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// MARK: - Frontegg Plist
 struct FronteggPlist: Decodable, Equatable {
     
     let keychainService: String
@@ -69,6 +70,7 @@ struct FronteggPlist: Decodable, Equatable {
     }
 }
 
+// MARK: - Payload
 extension FronteggPlist {
 
     enum Payload: Equatable {
@@ -91,6 +93,7 @@ extension FronteggPlist.Payload: Decodable {
     }
 }
 
+// MARK: - LogLevel
 extension FronteggPlist {
 
     enum LogLevel: String, Decodable {

--- a/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
@@ -9,57 +9,9 @@ import Foundation
 
 struct MultiRegionConfig: Decodable, Equatable {
 
-    let keychainService: String
     let regions: [RegionConfig]
-    let embeddedMode: Bool
-    let loginWithSocialLogin: Bool
-    let loginWithSSO: Bool
-    let lateInit: Bool
 
-    init(
-        keychainService: String,
-        regions: [RegionConfig],
-        embeddedMode: Bool = true,
-        loginWithSocialLogin: Bool = true,
-        loginWithSSO: Bool = false,
-        lateInit: Bool = false
-    ) {
-        self.keychainService = keychainService
-        self.embeddedMode = embeddedMode
+    init(regions: [RegionConfig]) {
         self.regions = regions
-        self.loginWithSocialLogin = loginWithSocialLogin
-        self.loginWithSSO = loginWithSSO
-        self.lateInit = lateInit
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        let keychainService = try container.decodeIfPresent(String.self, forKey: .keychainService)
-        self.keychainService = keychainService ?? "frontegg"
-
-        let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
-        self.embeddedMode = embeddedMode ?? true
-
-        let socialLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSocialLogin)
-        self.loginWithSocialLogin = socialLogin ?? true
-
-        let ssoLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSSO)
-        self.loginWithSSO = ssoLogin ?? false
-
-        let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
-        self.lateInit = lateInit ?? false
-
-        self.regions = try container.decode([RegionConfig].self, forKey: .regions)
-
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case keychainService
-        case embeddedMode
-        case regions
-        case loginWithSocialLogin
-        case loginWithSSO
-        case lateInit
     }
 }

--- a/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
@@ -1,0 +1,40 @@
+//
+//  MultiRegionConfig.swift
+//
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import Foundation
+
+struct MultiRegionConfig: Decodable, Equatable {
+
+    let keychainService: String
+    let embeddedMode: Bool
+    let regions: [RegionConfig]
+
+    init(keychainService: String, embeddedMode: Bool, regions: [RegionConfig]) {
+        self.keychainService = keychainService
+        self.embeddedMode = embeddedMode
+        self.regions = regions
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let keychainService = try container.decodeIfPresent(String.self, forKey: .keychainService)
+        self.keychainService = keychainService ?? "frontegg"
+
+        let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
+        self.embeddedMode = embeddedMode ?? true
+
+        self.regions = try container.decode([RegionConfig].self, forKey: .regions)
+
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case keychainService
+        case embeddedMode
+        case regions
+    }
+}

--- a/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
@@ -10,13 +10,26 @@ import Foundation
 struct MultiRegionConfig: Decodable, Equatable {
 
     let keychainService: String
-    let embeddedMode: Bool
     let regions: [RegionConfig]
+    let embeddedMode: Bool
+    let loginWithSocialLogin: Bool
+    let loginWithSSO: Bool
+    let lateInit: Bool
 
-    init(keychainService: String, embeddedMode: Bool, regions: [RegionConfig]) {
+    init(
+        keychainService: String,
+        regions: [RegionConfig],
+        embeddedMode: Bool = true,
+        loginWithSocialLogin: Bool = true,
+        loginWithSSO: Bool = false,
+        lateInit: Bool = false
+    ) {
         self.keychainService = keychainService
         self.embeddedMode = embeddedMode
         self.regions = regions
+        self.loginWithSocialLogin = loginWithSocialLogin
+        self.loginWithSSO = loginWithSSO
+        self.lateInit = lateInit
     }
 
     init(from decoder: any Decoder) throws {
@@ -28,6 +41,15 @@ struct MultiRegionConfig: Decodable, Equatable {
         let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
         self.embeddedMode = embeddedMode ?? true
 
+        let socialLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSocialLogin)
+        self.loginWithSocialLogin = socialLogin ?? true
+
+        let ssoLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSSO)
+        self.loginWithSSO = ssoLogin ?? false
+
+        let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
+        self.lateInit = lateInit ?? false
+
         self.regions = try container.decode([RegionConfig].self, forKey: .regions)
 
     }
@@ -36,5 +58,8 @@ struct MultiRegionConfig: Decodable, Equatable {
         case keychainService
         case embeddedMode
         case regions
+        case loginWithSocialLogin
+        case loginWithSSO
+        case lateInit
     }
 }

--- a/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/MultiRegionConfig.swift
@@ -14,4 +14,8 @@ struct MultiRegionConfig: Decodable, Equatable {
     init(regions: [RegionConfig]) {
         self.regions = regions
     }
+
+    enum CodingKeys: String, CodingKey {
+        case regions
+    }
 }

--- a/Sources/FronteggSwift/models/plist/RegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/RegionConfig.swift
@@ -1,0 +1,24 @@
+//
+//  Region.swift
+//
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import Foundation
+
+public struct RegionConfig: Decodable, Equatable, Identifiable {
+
+    public var id: String { key }
+    public let key: String
+    public let baseUrl: String
+    public let clientId: String
+    public let applicationId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case baseUrl
+        case clientId
+        case applicationId
+    }
+}

--- a/Sources/FronteggSwift/models/plist/RegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/RegionConfig.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct RegionConfig: Decodable, Equatable, Identifiable {
+public struct RegionConfig: Decodable, Equatable, Identifiable, Sendable, Hashable {
 
     public var id: String { key }
     public let key: String

--- a/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
@@ -8,52 +8,22 @@
 import Foundation
 struct SingleRegionConfig: Decodable, Equatable {
 
-    let keychainService: String
-    let embeddedMode: Bool
     let baseUrl: String
     let clientId: String
     let applicationId: String?
-    let loginWithSocialLogin: Bool
-    let loginWithSSO: Bool
-    let lateInit: Bool
 
     init(
-        keychainService: String,
         baseUrl: String,
         clientId: String,
-        applicationId: String? = nil,
-        embeddedMode: Bool = true,
-        loginWithSocialLogin: Bool = true,
-        loginWithSSO: Bool = false,
-        lateInit: Bool = false
+        applicationId: String? = nil
     ) {
-        self.keychainService = keychainService
         self.baseUrl = baseUrl
         self.clientId = clientId
         self.applicationId = applicationId
-        self.embeddedMode = embeddedMode
-        self.loginWithSocialLogin = loginWithSocialLogin
-        self.loginWithSSO = loginWithSSO
-        self.lateInit = lateInit
     }
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        let keychainService = try container.decodeIfPresent(String.self, forKey: .keychainService)
-        self.keychainService = keychainService ?? "frontegg"
-
-        let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
-        self.embeddedMode = embeddedMode ?? true
-        
-        let socialLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSocialLogin)
-        self.loginWithSocialLogin = socialLogin ?? true
-
-        let ssoLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSSO)
-        self.loginWithSSO = ssoLogin ?? false
-
-        let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
-        self.lateInit = lateInit ?? false
 
         self.baseUrl = try container.decode(String.self, forKey: .baseUrl)
         self.clientId = try container.decode(String.self, forKey: .clientId)
@@ -62,13 +32,8 @@ struct SingleRegionConfig: Decodable, Equatable {
     }
 
     enum CodingKeys: CodingKey {
-        case keychainService
         case baseUrl
         case clientId
         case applicationId
-        case embeddedMode
-        case loginWithSocialLogin
-        case loginWithSSO
-        case lateInit
     }
 }

--- a/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
@@ -13,13 +13,28 @@ struct SingleRegionConfig: Decodable, Equatable {
     let baseUrl: String
     let clientId: String
     let applicationId: String?
+    let loginWithSocialLogin: Bool
+    let loginWithSSO: Bool
+    let lateInit: Bool
 
-    init(keychainService: String, baseUrl: String, clientId: String, applicationId: String? = nil, embeddedMode: Bool) {
+    init(
+        keychainService: String,
+        baseUrl: String,
+        clientId: String,
+        applicationId: String? = nil,
+        embeddedMode: Bool = true,
+        loginWithSocialLogin: Bool = true,
+        loginWithSSO: Bool = false,
+        lateInit: Bool = false
+    ) {
         self.keychainService = keychainService
         self.baseUrl = baseUrl
         self.clientId = clientId
         self.applicationId = applicationId
         self.embeddedMode = embeddedMode
+        self.loginWithSocialLogin = loginWithSocialLogin
+        self.loginWithSSO = loginWithSSO
+        self.lateInit = lateInit
     }
 
     init(from decoder: any Decoder) throws {
@@ -30,6 +45,15 @@ struct SingleRegionConfig: Decodable, Equatable {
 
         let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
         self.embeddedMode = embeddedMode ?? true
+        
+        let socialLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSocialLogin)
+        self.loginWithSocialLogin = socialLogin ?? true
+
+        let ssoLogin = try container.decodeIfPresent(Bool.self, forKey: .loginWithSSO)
+        self.loginWithSSO = ssoLogin ?? false
+
+        let lateInit = try container.decodeIfPresent(Bool.self, forKey: .lateInit)
+        self.lateInit = lateInit ?? false
 
         self.baseUrl = try container.decode(String.self, forKey: .baseUrl)
         self.clientId = try container.decode(String.self, forKey: .clientId)
@@ -43,5 +67,8 @@ struct SingleRegionConfig: Decodable, Equatable {
         case clientId
         case applicationId
         case embeddedMode
+        case loginWithSocialLogin
+        case loginWithSSO
+        case lateInit
     }
 }

--- a/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
+++ b/Sources/FronteggSwift/models/plist/SingleRegionConfig.swift
@@ -1,0 +1,47 @@
+//
+//  SingleRegionConfig.swift
+//
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import Foundation
+struct SingleRegionConfig: Decodable, Equatable {
+
+    let keychainService: String
+    let embeddedMode: Bool
+    let baseUrl: String
+    let clientId: String
+    let applicationId: String?
+
+    init(keychainService: String, baseUrl: String, clientId: String, applicationId: String? = nil, embeddedMode: Bool) {
+        self.keychainService = keychainService
+        self.baseUrl = baseUrl
+        self.clientId = clientId
+        self.applicationId = applicationId
+        self.embeddedMode = embeddedMode
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let keychainService = try container.decodeIfPresent(String.self, forKey: .keychainService)
+        self.keychainService = keychainService ?? "frontegg"
+
+        let embeddedMode = try container.decodeIfPresent(Bool.self, forKey: .embeddedMode)
+        self.embeddedMode = embeddedMode ?? true
+
+        self.baseUrl = try container.decode(String.self, forKey: .baseUrl)
+        self.clientId = try container.decode(String.self, forKey: .clientId)
+        self.applicationId = try container.decodeIfPresent(String.self, forKey: .applicationId)
+
+    }
+
+    enum CodingKeys: CodingKey {
+        case keychainService
+        case baseUrl
+        case clientId
+        case applicationId
+        case embeddedMode
+    }
+}

--- a/Sources/FronteggSwift/utils/AuthorizeUrlGenerator.swift
+++ b/Sources/FronteggSwift/utils/AuthorizeUrlGenerator.swift
@@ -77,7 +77,7 @@ public class AuthorizeUrlGenerator {
                 return (url, codeVerifier)
             } else {
                 logger.error("Unkonwn error occured while generating authorize url, baseUrl: \(baseUrl)")
-                fatalError("Failed to generate authorize url")
+                fatalError(FronteggError.configError(.failedToGenerateAuthorizeURL).localizedDescription)
             }
         }
         
@@ -96,7 +96,7 @@ public class AuthorizeUrlGenerator {
             return (loginUrl.url!, codeVerifier)
         } else {
             logger.error("Unkonwn error occured while generating authorize url, baseUrl: \(baseUrl)")
-            fatalError("Failed to generate authorize url")
+            fatalError(FronteggError.configError(.failedToGenerateAuthorizeURL).localizedDescription)
         }
 
     }

--- a/Sources/FronteggSwift/utils/PlistHelper.swift
+++ b/Sources/FronteggSwift/utils/PlistHelper.swift
@@ -90,6 +90,12 @@ extension PlistHelper {
             let .keyNotFound(key, _) where key.stringValue == RegionConfig.CodingKeys.baseUrl.stringValue,
             let .keyNotFound(key, _) where key.stringValue == RegionConfig.CodingKeys.clientId.stringValue:
             return FronteggError.Configuration.missingClientIdOrBaseURL(path)
+        case
+            let .keyNotFound(key, _) where key.stringValue == MultiRegionConfig.CodingKeys.regions.stringValue:
+            return FronteggError.Configuration.missingRegions
+        case
+            let .keyNotFound(key, _) where key.stringValue == RegionConfig.CodingKeys.key.stringValue:
+            return FronteggError.Configuration.invalidRegions(path)
         default:
             return error
         }

--- a/Sources/FronteggSwift/utils/PlistHelper.swift
+++ b/Sources/FronteggSwift/utils/PlistHelper.swift
@@ -13,6 +13,8 @@ struct PlistHelper {
     private static var logger = getLogger("PlistHelper")
     private static let decoder = PropertyListDecoder()
 
+    /// Decodes the Frontegg configuration plist and logs any error that occurs
+    /// - Returns: the decoded model (``FronteggPlist``)
     static func fronteggConfig() throws -> FronteggPlist {
 
         do {
@@ -22,7 +24,9 @@ struct PlistHelper {
             throw error
         }
     }
-
+    
+    /// Decodes the Frontegg configuration plist
+    /// - Returns: the decoded model (``FronteggPlist``)
     private static func plist() throws -> FronteggPlist {
 
         let resourceName = (getenv("frontegg-testing") != nil) ? "FronteggTest" : "Frontegg"
@@ -36,7 +40,9 @@ struct PlistHelper {
 
         return try decode(FronteggPlist.self, from: data, at: url.path)
     }
-
+    
+    /// Gets the required log level from cache if it exists, or attempts to read it from the Frontegg configuration plist if it wasn't previously loaded
+    /// - Returns: the required logger level (``Logger/Level``)
     static func getLogLevel() -> Logger.Level {
         
         if let logLevel = PlistHelper.logLevelCache {
@@ -54,7 +60,13 @@ struct PlistHelper {
 }
 
 extension PlistHelper {
-
+    
+    /// Decodes a plist model using a PropertyListDecoder, and maps the errors to the internal ``FronteggError`` before logging and rethrowing them. Any unmapped errors will be logged and thrown
+    /// - Parameters:
+    ///   - type: The type to decode
+    ///   - data: The data to decode the model from
+    ///   - path: The path of the plist
+    /// - Returns: The decoded model
     static func decode<Plist: Decodable>(_ type: Plist.Type, from data: Data, at path: String) throws -> Plist {
         do {
             return try decoder.decode(type, from: data)
@@ -72,7 +84,12 @@ extension PlistHelper {
 
 // MARK: - Error mapping
 extension PlistHelper {
-
+    
+    /// Maps a DecodingError to the internal ``FronteggError``
+    /// - Parameters:
+    ///   - error: the decoding error to attempt to map
+    ///   - path: the path of the plist (used as part of some of the error description)
+    /// - Returns: A ``FronteggError`` if any mapping was found, or the original, unmapped error otherwise
     private static func map(decodingError error: DecodingError, at path: String) -> any Error {
         switch error {
         case

--- a/Sources/FronteggSwift/utils/PlistHelper.swift
+++ b/Sources/FronteggSwift/utils/PlistHelper.swift
@@ -50,11 +50,6 @@ struct PlistHelper {
             return .warning
         }
     }
-
-    public static func bundleIdentifier() -> String {
-        let bundle = Bundle.main;
-        return bundle.bundleIdentifier!
-    }
     
 }
 

--- a/Sources/FronteggSwift/utils/PlistHelper.swift
+++ b/Sources/FronteggSwift/utils/PlistHelper.swift
@@ -29,64 +29,7 @@ struct PlistHelper {
         return try decode(FronteggPlist.self, from: data, at: url.path)
     }
 
-    public static func fronteggConfig() throws -> SingleRegionConfig {
-
-        let resourceName = (getenv("frontegg-testing") != nil) ? "FronteggTest" : "Frontegg"
-        
-        guard 
-            let url = Bundle.main.url(forResource: resourceName, withExtension: "plist"),
-            let data = try? Data(contentsOf: url)
-        else {
-            let error = FronteggError.configError(.missingPlist)
-            logger.debug(error.localizedDescription)
-            throw error
-        }
-
-        return try decode(SingleRegionConfig.self, from: data, at: url.path)
-    }
-    
-    public static func fronteggRegionalConfig() throws -> (regions: [RegionConfig], keychainService: String, bundleIdentifier: String) {
-        let bundle = Bundle.main;
-        
-        let resourceName = (getenv("frontegg-testing") != nil) ? "FronteggTest" : "Frontegg"
-        
-        guard let path = bundle.path(forResource: resourceName, ofType: "plist"),
-              let values = NSDictionary(contentsOfFile: path) as? [String: Any] else {
-            let error = FronteggError.configError(.missingPlist)
-            logger.debug(error.localizedDescription)
-            throw error
-        }
-        
-        guard 
-            let regions = values["regions"] as? [[String: String]],
-            !regions.isEmpty
-        else {
-            let error = FronteggError.configError(.missingRegions)
-            logger.debug(error.localizedDescription)
-            throw error
-        }
-        
-        let keychainService = values["keychainService"] as? String ?? "frontegg"
-        
-        let regionConfigs = try regions.map { dict in
-            guard 
-                let key = dict["key"],
-                let baseUrl = dict["baseUrl"],
-                let clientId = dict["clientId"] 
-            else {
-                let error = FronteggError.configError(.invalidRegions(path))
-                logger.debug(error.localizedDescription)
-                throw error
-            }
-
-            let applicationId = dict["applicationId"]
-            return RegionConfig(key: key, baseUrl: baseUrl, clientId: clientId, applicationId: applicationId)
-        }
-        return (regions: regionConfigs, keychainService: keychainService, bundleIdentifier: bundle.bundleIdentifier!)
-    }
-    
-    
-    public static func getLogLevel() -> Logger.Level {
+    static func getLogLevel() -> Logger.Level {
         
         if let logLevel = PlistHelper.logLevelCache {
             return logLevel
@@ -113,69 +56,10 @@ struct PlistHelper {
         
         return Logger.Level.warning
     }
-    
-    
-    
+
     public static func bundleIdentifier() -> String {
         let bundle = Bundle.main;
         return bundle.bundleIdentifier!
-    }
-    
-
-    
-    public static func isEmbeddedMode() -> Bool {
-        
-        let bundle = Bundle.main;
-        if let path = bundle.path(forResource: "Frontegg", ofType: "plist"),
-           let values = NSDictionary(contentsOfFile: path) as? [String: Any],
-           let embeddedMode =  values["embeddedMode"] as? Bool {
-            
-            return embeddedMode
-        }
-        
-        return true
-    }
-    
-    public static func isLateInit() -> Bool {
-        let bundle = Bundle.main;
-        if let path = bundle.path(forResource: "Frontegg", ofType: "plist"),
-           let values = NSDictionary(contentsOfFile: path) as? [String: Any],
-           let lateInit =  values["lateInit"] as? Bool {
-            
-           return lateInit
-        }
-        return false
-    }
-    
-    
-    public static func getKeychainService() -> String {
-        let bundle = Bundle.main;
-        if let path = bundle.path(forResource: "Frontegg", ofType: "plist"),
-           let values = NSDictionary(contentsOfFile: path) as? [String: Any],
-           let keychainService =  values["keychainService"] as? String {
-            
-           return keychainService
-        }
-        return "frontegg"
-    }
-    
-    public static func getNativeBridgeOptions() -> [String: Bool] {
-        let bundle = Bundle.main;
-        
-        var loginWithSocialLogin:Bool = true
-        var loginWithSSO:Bool = false
-        
-        if let path = bundle.path(forResource: "Frontegg", ofType: "plist"),
-           let values = NSDictionary(contentsOfFile: path) as? [String: Any] {
-            
-            loginWithSocialLogin = (values["loginWithSocialLogin"] as? Bool) ?? true
-            loginWithSSO = (values["loginWithSSO"] as? Bool) ?? false
-            
-        }
-        return [
-            "loginWithSocialLogin": loginWithSocialLogin,
-            "loginWithSSO": loginWithSSO
-        ]
     }
     
 }

--- a/Sources/FronteggSwift/views/AbstractFronteggController.swift
+++ b/Sources/FronteggSwift/views/AbstractFronteggController.swift
@@ -15,7 +15,7 @@ open class AbstractFronteggController: UIViewController {
     
     open func navigateToAuthenticated() {
         logger.error("Missing AbstractFronteggController implementation class")
-        fatalError("Not implemented")
+        assertionFailure("Not implemented")
     }
     
     public override func viewDidLoad() {

--- a/Tests/FronteggSwiftTests/MockRegion.swift
+++ b/Tests/FronteggSwiftTests/MockRegion.swift
@@ -10,9 +10,11 @@ import XCTest
 enum MockRegion: String {
 
     case validSingleRegion
+    case validSingleRegionMinimumKeys
     case singleRegionMissingBaseUrl
     case singleRegionMissingClientId
     case validMultiRegion
+    case validMultiRegionMinimumKeys
     case multiRegionMissingBaseUrl
     case multiRegionMissingClientId
 

--- a/Tests/FronteggSwiftTests/MockRegion.swift
+++ b/Tests/FronteggSwiftTests/MockRegion.swift
@@ -17,6 +17,8 @@ enum MockRegion: String {
     case validMultiRegionMinimumKeys
     case multiRegionMissingBaseUrl
     case multiRegionMissingClientId
+    case multiRegionMissingRegions
+    case multiRegionMissingKey
 
     var url: URL {
         get throws {

--- a/Tests/FronteggSwiftTests/MockRegion.swift
+++ b/Tests/FronteggSwiftTests/MockRegion.swift
@@ -1,0 +1,30 @@
+//
+//  MockRegion.swift
+//  
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import XCTest
+
+enum MockRegion: String {
+
+    case validSingleRegion
+    case singleRegionMissingBaseUrl
+    case singleRegionMissingClientId
+    case validMultiRegion
+    case multiRegionMissingBaseUrl
+    case multiRegionMissingClientId
+
+    var url: URL {
+        get throws {
+            let filename = self.rawValue.prefix(1).uppercased() + self.rawValue.dropFirst()
+            return try XCTUnwrap(Bundle.module.url(forResource: "MockRegions/\(filename)", withExtension: "plist"))
+        }
+    }
+    var data: Data {
+        get throws {
+            return try Data(contentsOf: url)
+        }
+    }
+}

--- a/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingBaseUrl.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingBaseUrl.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>regions</key>
+	<array>
+		<dict>
+			<key>key</key>
+			<string>region1</string>
+			<key>clientId</key>
+			<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+		</dict>
+		<dict>
+			<key>key</key>
+			<string>region2</string>
+			<key>baseUrl</key>
+			<string>https://region2.test.com</string>
+			<key>clientId</key>
+			<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingClientId.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingClientId.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>regions</key>
+	<array>
+		<dict>
+			<key>key</key>
+			<string>region1</string>
+			<key>baseUrl</key>
+			<string>https://region1.test.com</string>
+		</dict>
+		<dict>
+			<key>key</key>
+			<string>region2</string>
+			<key>baseUrl</key>
+			<string>https://region2.test.com</string>
+			<key>clientId</key>
+			<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingKey.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingKey.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>keychainService</key>
+	<string>testService</string>
+	<key>regions</key>
+	<array>
+		<dict>
+			<key>baseUrl</key>
+			<string>https://region1.test.com</string>
+			<key>clientId</key>
+			<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+			<key>applicationId</key>
+			<string>549e3240-84e2-495a-91ea-be467f807272</string>
+		</dict>
+		<dict>
+			<key>key</key>
+			<string>region2</string>
+			<key>baseUrl</key>
+			<string>https://region2.test.com</string>
+			<key>clientId</key>
+			<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+			<key>applicationId</key>
+			<string>199d93c3-0d82-4eac-ab95-4b9e3d617053</string>
+		</dict>
+	</array>
+	<key>loginWithSocialLogin</key>
+	<false/>
+	<key>loginWithSSO</key>
+	<true/>
+	<key>lateInit</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingRegions.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/MultiRegionMissingRegions.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/SingleRegionMissingBaseUrl.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/SingleRegionMissingBaseUrl.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>clientId</key>
+	<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/SingleRegionMissingClientId.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/SingleRegionMissingClientId.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>baseUrl</key>
+	<string>https://test.com</string>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
@@ -35,5 +35,7 @@
 	<true/>
 	<key>lateInit</key>
 	<true/>
+	<key>logLevel</key>
+	<string>critical</string>
 </dict>
 </plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>keychainService</key>
+	<string>testService</string>
+	<key>regions</key>
+	<array>
+		<dict>
+			<key>key</key>
+			<string>region1</string>
+			<key>baseUrl</key>
+			<string>https://region1.test.com</string>
+			<key>clientId</key>
+			<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+			<key>applicationId</key>
+			<string>549e3240-84e2-495a-91ea-be467f807272</string>
+		</dict>
+		<dict>
+			<key>key</key>
+			<string>region2</string>
+			<key>baseUrl</key>
+			<string>https://region2.test.com</string>
+			<key>clientId</key>
+			<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+			<key>applicationId</key>
+			<string>199d93c3-0d82-4eac-ab95-4b9e3d617053</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegion.plist
@@ -29,5 +29,11 @@
 			<string>199d93c3-0d82-4eac-ab95-4b9e3d617053</string>
 		</dict>
 	</array>
+	<key>loginWithSocialLogin</key>
+	<false/>
+	<key>loginWithSSO</key>
+	<true/>
+	<key>lateInit</key>
+	<true/>
 </dict>
 </plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegionMinimumKeys.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidMultiRegionMinimumKeys.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>regions</key>
+	<array>
+		<dict>
+			<key>key</key>
+			<string>region1</string>
+			<key>baseUrl</key>
+			<string>https://region1.test.com</string>
+			<key>clientId</key>
+			<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+		</dict>
+		<dict>
+			<key>key</key>
+			<string>region2</string>
+			<key>baseUrl</key>
+			<string>https://region2.test.com</string>
+			<key>clientId</key>
+			<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
@@ -12,5 +12,11 @@
 	<string>https://test.com</string>
 	<key>clientId</key>
 	<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+	<key>loginWithSocialLogin</key>
+	<false/>
+	<key>loginWithSSO</key>
+	<true/>
+	<key>lateInit</key>
+	<true/>
 </dict>
 </plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>embeddedMode</key>
+	<false/>
+	<key>keychainService</key>
+	<string>testService</string>
+	<key>applicationId</key>
+	<string>f87f8fea-8cb3-4a46-bab8-0169726a5704</string>
+	<key>baseUrl</key>
+	<string>https://test.com</string>
+	<key>clientId</key>
+	<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegion.plist
@@ -18,5 +18,7 @@
 	<true/>
 	<key>lateInit</key>
 	<true/>
+	<key>logLevel</key>
+	<string>critical</string>
 </dict>
 </plist>

--- a/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegionMinimumKeys.plist
+++ b/Tests/FronteggSwiftTests/MockRegions/ValidSingleRegionMinimumKeys.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>baseUrl</key>
+	<string>https://test.com</string>
+	<key>clientId</key>
+	<string>d37ad699-e466-451a-a9d1-d590869dba1a</string>
+</dict>
+</plist>

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -13,7 +13,7 @@ final class PlistHelperTests: XCTestCase {}
 // MARK: - Valid FronteggConfig Tests
 extension PlistHelperTests {
 
-    func test_decodePlist_willDecodeSingleRegionCorrectly() throws {
+    func test_decodePlist_willDecodeSingleRegionCorrectly_whenAllKeysProvided() throws {
 
         let expectedPlist = FronteggPlist(
             keychainService: "testService",
@@ -37,7 +37,7 @@ extension PlistHelperTests {
         XCTAssertEqual(expectedPlist, decodedPlist)
     }
 
-    func test_decodePlist_willDecodeMultiRegionCorrectly() throws {
+    func test_decodePlist_willDecodeMultiRegionCorrectly_whenAllKeysProvided() throws {
 
         let expectedPlist = FronteggPlist(
             keychainService: "testService",

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -67,6 +67,61 @@ extension PlistHelperTests {
 
         XCTAssertEqual(expectedPlist, decodedPlist)
     }
+
+    func test_decodePlist_willDecodeSingleRegionCorrectly_whenMinimumKeysProvided() throws {
+
+        let expectedPlist = FronteggPlist(
+            keychainService: "frontegg",
+            embeddedMode: true,
+            loginWithSocialLogin: true,
+            loginWithSSO: false,
+            lateInit: false,
+            payload: .singleRegion(.init(
+                baseUrl: "https://test.com",
+                clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
+                applicationId: nil
+            ))
+        )
+        let decodedPlist = try PlistHelper.decode(
+            FronteggPlist.self,
+            from: MockRegion.validSingleRegionMinimumKeys.data,
+            at: "testPath"
+        )
+
+        XCTAssertEqual(expectedPlist, decodedPlist)
+    }
+
+    func test_decodePlist_willDecodeMultiRegionCorrectly_whenMinimumKeysProvided() throws {
+
+        let expectedPlist = FronteggPlist(
+            keychainService: "frontegg",
+            embeddedMode: true,
+            loginWithSocialLogin: true,
+            loginWithSSO: false,
+            lateInit: false,
+            payload: .multiRegion(.init(regions: [
+                .init(
+                    key: "region1",
+                    baseUrl: "https://region1.test.com",
+                    clientId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
+                    applicationId: nil
+                ),
+                .init(
+                    key: "region2",
+                    baseUrl: "https://region2.test.com",
+                    clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
+                    applicationId: nil
+                )
+            ]))
+        )
+        let decodedPlist = try PlistHelper.decode(
+            FronteggPlist.self,
+            from: MockRegion.validMultiRegionMinimumKeys.data,
+            at: "testPath"
+        )
+
+        XCTAssertEqual(expectedPlist, decodedPlist)
+    }
 }
 
 // MARK: - DecodingError Mapping Tests

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -21,6 +21,7 @@ extension PlistHelperTests {
             loginWithSocialLogin: false,
             loginWithSSO: true,
             lateInit: true,
+            logLevel: .critical,
             payload: .singleRegion(.init(
                 baseUrl: "https://test.com",
                 clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
@@ -44,6 +45,7 @@ extension PlistHelperTests {
             loginWithSocialLogin: false,
             loginWithSSO: true,
             lateInit: true,
+            logLevel: .critical,
             payload: .multiRegion(.init(regions: [
                 .init(
                     key: "region1",
@@ -76,6 +78,7 @@ extension PlistHelperTests {
             loginWithSocialLogin: true,
             loginWithSSO: false,
             lateInit: false,
+            logLevel: .warn,
             payload: .singleRegion(.init(
                 baseUrl: "https://test.com",
                 clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
@@ -99,6 +102,7 @@ extension PlistHelperTests {
             loginWithSocialLogin: true,
             loginWithSSO: false,
             lateInit: false,
+            logLevel: .warn,
             payload: .multiRegion(.init(regions: [
                 .init(
                     key: "region1",

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -15,14 +15,17 @@ extension PlistHelperTests {
 
     func test_decodePlist_willDecodeSingleRegionCorrectly() throws {
 
-        let expectedPlist = FronteggPlist.singleRegion(
-            .init(
-                keychainService: "testService",
+        let expectedPlist = FronteggPlist(
+            keychainService: "testService",
+            embeddedMode: false,
+            loginWithSocialLogin: false,
+            loginWithSSO: true,
+            lateInit: true,
+            payload: .singleRegion(.init(
                 baseUrl: "https://test.com",
                 clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
-                applicationId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
-                embeddedMode: false
-            )
+                applicationId: "f87f8fea-8cb3-4a46-bab8-0169726a5704"
+            ))
         )
         let decodedPlist = try PlistHelper.decode(
             FronteggPlist.self,
@@ -35,25 +38,26 @@ extension PlistHelperTests {
 
     func test_decodePlist_willDecodeMultiRegionCorrectly() throws {
 
-        let expectedPlist = FronteggPlist.multiRegion(
-            .init(
-                keychainService: "testService",
-                embeddedMode: false,
-                regions: [
-                    .init(
-                        key: "region1",
-                        baseUrl: "https://region1.test.com",
-                        clientId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
-                        applicationId: "549e3240-84e2-495a-91ea-be467f807272"
-                    ),
-                    .init(
-                        key: "region2",
-                        baseUrl: "https://region2.test.com",
-                        clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
-                        applicationId: "199d93c3-0d82-4eac-ab95-4b9e3d617053"
-                    )
-                ]
-            )
+        let expectedPlist = FronteggPlist(
+            keychainService: "testService",
+            embeddedMode: false,
+            loginWithSocialLogin: false,
+            loginWithSSO: true,
+            lateInit: true,
+            payload: .multiRegion(.init(regions: [
+                .init(
+                    key: "region1",
+                    baseUrl: "https://region1.test.com",
+                    clientId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
+                    applicationId: "549e3240-84e2-495a-91ea-be467f807272"
+                ),
+                .init(
+                    key: "region2",
+                    baseUrl: "https://region2.test.com",
+                    clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
+                    applicationId: "199d93c3-0d82-4eac-ab95-4b9e3d617053"
+                )
+            ]))
         )
         let decodedPlist = try PlistHelper.decode(
             FronteggPlist.self,

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -180,6 +180,32 @@ extension PlistHelperTests {
             XCTAssertEqual(error as? FronteggError.Configuration, .missingClientIdOrBaseURL("testPath"))
         }
     }
-}
 
-private struct TestError: Error {}
+    func test_decodeMultiRegion_willThrowCorrectError_whenRegionIsMissing() throws {
+
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                MultiRegionConfig.self,
+                from: MockRegion.multiRegionMissingRegions.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .missingRegions)
+        }
+    }
+
+    func test_decodeMultiRegion_willThrowCorrectError_whenKeyIsMissing() throws {
+
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                MultiRegionConfig.self,
+                from: MockRegion.multiRegionMissingKey.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .invalidRegions("testPath"))
+        }
+    }
+}

--- a/Tests/FronteggSwiftTests/PlistHelperTests.swift
+++ b/Tests/FronteggSwiftTests/PlistHelperTests.swift
@@ -1,0 +1,126 @@
+//
+//  File.swift
+//  
+//
+//  Created by Nick Hagi on 25/07/2024.
+//
+
+import XCTest
+@testable import FronteggSwift
+
+final class PlistHelperTests: XCTestCase {}
+
+// MARK: - Valid FronteggConfig Tests
+extension PlistHelperTests {
+
+    func test_decodePlist_willDecodeSingleRegionCorrectly() throws {
+
+        let expectedPlist = FronteggPlist.singleRegion(
+            .init(
+                keychainService: "testService",
+                baseUrl: "https://test.com",
+                clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
+                applicationId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
+                embeddedMode: false
+            )
+        )
+        let decodedPlist = try PlistHelper.decode(
+            FronteggPlist.self,
+            from: MockRegion.validSingleRegion.data,
+            at: "testPath"
+        )
+
+        XCTAssertEqual(expectedPlist, decodedPlist)
+    }
+
+    func test_decodePlist_willDecodeMultiRegionCorrectly() throws {
+
+        let expectedPlist = FronteggPlist.multiRegion(
+            .init(
+                keychainService: "testService",
+                embeddedMode: false,
+                regions: [
+                    .init(
+                        key: "region1",
+                        baseUrl: "https://region1.test.com",
+                        clientId: "f87f8fea-8cb3-4a46-bab8-0169726a5704",
+                        applicationId: "549e3240-84e2-495a-91ea-be467f807272"
+                    ),
+                    .init(
+                        key: "region2",
+                        baseUrl: "https://region2.test.com",
+                        clientId: "d37ad699-e466-451a-a9d1-d590869dba1a",
+                        applicationId: "199d93c3-0d82-4eac-ab95-4b9e3d617053"
+                    )
+                ]
+            )
+        )
+        let decodedPlist = try PlistHelper.decode(
+            FronteggPlist.self,
+            from: MockRegion.validMultiRegion.data,
+            at: "testPath"
+        )
+
+        XCTAssertEqual(expectedPlist, decodedPlist)
+    }
+}
+
+// MARK: - DecodingError Mapping Tests
+extension PlistHelperTests {
+
+    func test_decodeSingleRegion_willThrowCorrectError_whenBaseUrlIsMissing() throws {
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                SingleRegionConfig.self,
+                from: MockRegion.singleRegionMissingBaseUrl.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .missingClientIdOrBaseURL("testPath"))
+        }
+    }
+
+    func test_decodeSingleRegion_willThrowCorrectError_whenClientIdIsMissing() throws {
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                SingleRegionConfig.self,
+                from: MockRegion.singleRegionMissingClientId.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .missingClientIdOrBaseURL("testPath"))
+        }
+    }
+
+    func test_decodeMultiRegion_willThrowCorrectError_whenBaseUrlIsMissing() throws {
+
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                MultiRegionConfig.self,
+                from: MockRegion.multiRegionMissingBaseUrl.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .missingClientIdOrBaseURL("testPath"))
+        }
+    }
+
+    func test_decodeMultiRegion_willThrowCorrectError_whenClientIdIsMissing() throws {
+
+
+        XCTAssertThrowsError(
+            try PlistHelper.decode(
+                MultiRegionConfig.self,
+                from: MockRegion.multiRegionMissingClientId.data,
+                at: "testPath"
+            )
+        ) { error in
+            XCTAssertEqual(error as? FronteggError.Configuration, .missingClientIdOrBaseURL("testPath"))
+        }
+    }
+}
+
+private struct TestError: Error {}


### PR DESCRIPTION
## Overview

This PR refactors the way the main Frontegg.plist file is being read by the SDK. The config plist is now being decoded as a type-safe model as opposed to individual properties via serialisation. There are several advantages to this approach:
- Type-safe way to access the properties of the plist
- Centralised access to all properties of the plist as opposed to individual helper methods
- A `Decodable` model only enforces the plist to have the required keys, allowing clients of the sdk to add additional properties to the plist without breaking decoding for the SDK
- The `FronteggPlist`, `MultiRegionConfig`, and `SingleRegionConfig` models now provide a central location for clients to view all the possible properties and variations that can be configured in the plist

The models have been implemented with explicit conformance to Decodable in order to be able to have non-optional types which have a default value if clients don't define them (same behaviour as before). The default values have been set to the same defaults as the previous implementation in order to avoid breaking client implementations:
- `keychainService`: `frontegg`
- `embeddedMode`: `true`
- `loginWithSocialLogin`: `true`
- `loginWithSSO`: `false`
- `lateInit`: `false`
- `logLevel`: `.warn`

A unit test target was introduced in order to verify the correct behaviour of the model decoding. The test case is not an exhaustive test of the PlistHelper, but it adds tests for the new implementation of plist decoding for multiple variations (valid/invalid plists, minimum required keys, all keys defined, etc.), and the mapping of DecodingError to a `FronteggError`

Additionally, some of the failure behaviour was changed from `exit(1)` to `fatalError`, as the previous implementation wouldn't report the exit errors to clients of the SDK and would detach the debugger with no error message.

## Motivation

During the frontegg implementation in our app we needed a way to map Frontegg's auth environments / regions to specific backend environments on our side - e.g:
- if the app authenticates on the staging Frontegg environment, subsequent requests to our backend would be sent to one of our UAT backend environments (presenting a choice to the user where they can select from a list of available backend environments that is compatible with their choice of Frontegg auth environment)
- if the app authenticates on the production Frontegg environment, subsequent requests to our backend would be sent directly to our prod backend environment

We heavily rely on Tuist and Swiftgen to generate type-safe models for our resources, and when we added the environment mapping into the Frontegg plist for Swiftgen purposes, the app started closing (without crashing or displaying any errors in the Xcode console) on launch. Upon investigation it turned out that:
- The PlistHelper was attempting to decode a region as [String: String], but decoding was failing because of the added dictionary of available environments to the region
- Failing to decode both a multi-region plist and a single-region plist, the FronteggApp init was calling exit(1) which would detach the debugger and close the app without reporting any errors

Given the above, resolving this issue could've been achieved by simply deserialising a [String: AnyObject] instead of [String: String], and casting just the `key`, `baseUrl`, `clientId`, and `applicationId` as Strings, but it felt more like a plaster rather than a fix, so I ended up going down the rabbit-hole and refactored into models instead.