### PR TITLE
Reschedule token refresh if internet is inactive

### DIFF
--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -364,6 +364,14 @@ public class FronteggAuth: ObservableObject {
     }
     
     public func refreshTokenIfNeeded() async -> Bool {
+        
+        guard await NetworkStatusMonitor.isActive else {
+            self.logger.info("Refresh rescheduled due to inactive internet")
+
+            scheduleTokenRefresh(offset: 10)
+            return false
+        }
+
         guard let refreshToken = self.refreshToken else {
             self.logger.info("no refresh token found")
             return false

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -1,0 +1,35 @@
+//
+//  NetworkStatusMonitor.swift
+//
+//
+//  Created by Nick Hagi on 18/09/2024.
+//
+
+import Foundation
+import Network
+
+struct NetworkStatusMonitor {
+
+    private static let queue = DispatchQueue(label: "NetworkStatusMonitor")
+
+    static var isActive: Bool {
+        get async {
+            let monitor = NWPathMonitor()
+            let result = await withCheckedContinuation { continuation in
+
+                monitor.pathUpdateHandler = { path in
+                    switch path.status {
+                    case .satisfied:
+                        continuation.resume(returning: true)
+                    default:
+                        continuation.resume(returning: false)
+                    }
+                }
+
+                monitor.start(queue: queue)
+            }
+            monitor.cancel()
+            return result
+        }
+    }
+}


### PR DESCRIPTION
# Overview
This PR resolves an issue where the automatic token refresh functionality logs users out when there is no internet connection available, and the scheduled refresh attempts to do the API call.

In the current implementation, any refresh API call failure (including no internet connection) results in the access token, refresh token, and other related properties (e.g. `isAuthenticated`) to be cleared/reset.

The proposed solution is to check whether or not there is an active internet connection before even attempting to do the refresh, and if there isn't one, the refresh will be rescheduled for retry in 10 seconds rather than logging the user out. The 10 second reschedule is set to a short enough amount of time that if the internet becomes available again, the refresh can be done without too much delay.

# Motivation
During our initial integration of Frontegg, we noticed some strange behaviour for re-auth while the device has no internet connection. Our app is designed to also work offline post-login, and the result was that every time users went back online (after the access token expired, but the refresh was still valid) they would be asked to log in again (especially frustrating if they are logged in via SSO and need to use the authenticator again).

# Steps to reproduce
- set the environment JWT expiry to a short value (e.g. 60 seconds) and the refresh to a long value (e.g. 3 days)
- log into the app
- turn wifi & cellular data off
- wait 60s for the access token to expire
- turn wifi back on
- Notice `FronteggAuth.shared.accessToken`, `FronteggAuth.shared.refreshToken`, `FronteggAuth.shared.user` are now `nil`
- Notice `FronteggAuth.shared.isAuthenticated` is `false`

Expected: token, refresh token, user to be unchanged, and isAuthenticated to still be true, especially since the refresh token is not yet expired