### PR TITLE
FR-19479 added remainCodeVerifier

### DIFF
--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -684,7 +684,14 @@ public class FronteggAuth: ObservableObject {
         WebAuthenticator.shared.start(authorizeUrl, ephemeralSession: ephemeralSession ?? true, window:window,  completionHandler: oauthCallback)
     }
     
-    public func directLoginAction(window: UIWindow?, type: String, data: String, ephemeralSession: Bool? = true, _completion: FronteggAuth.CompletionHandler? = nil, additionalQueryParams: [String: Any]? = nil) {
+    public func directLoginAction(
+        window: UIWindow?, 
+        type: String, 
+        data: String, 
+        ephemeralSession: Bool? = true, 
+        _completion: FronteggAuth.CompletionHandler? = nil, 
+        additionalQueryParams: [String: Any]? = nil, 
+        remainCodeVerifier: Bool = false) {
         
         
         let completion = _completion ?? { res in
@@ -709,7 +716,7 @@ public class FronteggAuth: ObservableObject {
         var generatedUrl: (URL, String)
         if let jsonData = try? JSONSerialization.data(withJSONObject: directLogin, options: []) {
             let jsonString = jsonData.base64EncodedString()
-            generatedUrl = AuthorizeUrlGenerator.shared.generate(loginAction: jsonString)
+            generatedUrl = AuthorizeUrlGenerator.shared.generate(loginAction: jsonString, remainCodeVerifier: remainCodeVerifier)
         } else {
             generatedUrl = AuthorizeUrlGenerator.shared.generate()
         }

--- a/Sources/FronteggSwift/embedded/FronteggWKContentController.swift
+++ b/Sources/FronteggSwift/embedded/FronteggWKContentController.swift
@@ -79,7 +79,8 @@ class FronteggWKContentController: NSObject, WKScriptMessageHandler {
                                                   ephemeralSession: false,
                                                   additionalQueryParams: [
                                                     "prompt":"consent"
-                                                  ])
+                                                  ],
+                                                  remainCodeVerifier: true)
         case "loginWithCustomSocialLoginProvider":
             FronteggAuth.shared.directLoginAction(window: nil,
                                                   type: "custom-social-login",
@@ -87,7 +88,8 @@ class FronteggWKContentController: NSObject, WKScriptMessageHandler {
                                                   ephemeralSession: false,
                                                   additionalQueryParams: [
                                                     "prompt":"consent"
-                                                  ])
+                                                  ],
+                                                  remainCodeVerifier: true)
         case "suggestSavePassword":
             guard let data = try? JSONSerialization.jsonObject(with: Data(message.payload.utf8), options: []) as? [String: String],
                   let email = data["email"],

--- a/Sources/FronteggSwift/services/Api.swift
+++ b/Sources/FronteggSwift/services/Api.swift
@@ -234,9 +234,14 @@ public class Api {
                 "redirect_uri": redirectUrl,
                 "code_verifier": codeVerifier,
             ])
-            
+
+            if let responseString = String(data: data, encoding: .utf8),
+               responseString.contains("\"errors\"") || responseString.contains("\"error\"") {
+                return (nil, FronteggError.authError(.other(NSError(domain: "FronteggAuth", code: 400, userInfo: [NSLocalizedDescriptionKey: responseString]))))
+            }
+
             return (try JSONDecoder().decode(AuthResponse.self, from: data), nil)
-        }catch {
+        } catch {
             return (nil, FronteggError.authError(.couldNotExchangeToken(error.localizedDescription)))
         }
     }


### PR DESCRIPTION
- added `remainCodeVerifier` for social logins
- check for API errors before decoding to prevent JSON decoding from failing due to unexpected format