### PR TITLE
Add automatic legacy social login flow detection

### DIFF
--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -993,6 +993,16 @@ public class FronteggAuth: FronteggState {
                 nil
             }
             
+            // Check if we need to use legacy flow
+            if generatedAuthUrl == nil && !custom {
+                if let provider = SocialLoginProvider(rawValue: providerString),
+                   let legacyUrl = try? await SocialLoginUrlGenerator.shared.legacyAuthorizeURL(for: provider, action: action) {
+                    logger.debug("Using legacy social login flow for provider: \(providerString)")
+                    self.loginWithSocialLogin(socialLoginUrl: legacyUrl, done)
+                    return
+                }
+            }
+            
             guard let authURL = generatedAuthUrl else {
                 self.logger.error("Failed to generate auth URL for \(providerString)")
                 return

--- a/Sources/FronteggSwift/embedded/FronteggWKContentController.swift
+++ b/Sources/FronteggSwift/embedded/FronteggWKContentController.swift
@@ -133,7 +133,7 @@ class FronteggWKContentController: NSObject, WKScriptMessageHandler {
                     providerString: message.payload,
                     custom: false,
                     action: formAction,
-                    completion: self.socialLoginHandler,
+                    completion: self.socialLoginHandler
                 )
             }
         case "loginWithCustomSocialLoginProvider":
@@ -154,7 +154,7 @@ class FronteggWKContentController: NSObject, WKScriptMessageHandler {
                     providerString: message.payload,
                     custom: true,
                     action: formAction,
-                    completion: self.socialLoginHandler,
+                    completion: self.socialLoginHandler
                 )
             }
         case "suggestSavePassword":

--- a/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
+++ b/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
@@ -142,8 +142,21 @@ public final class SocialLoginUrlGenerator {
         
         // Convert relative URL to absolute
         let fullURL = "\(FronteggAuth.shared.baseUrl)\(authURLString)"
-        logger.debug("Generated legacy URL for \(provider.rawValue): \(fullURL)")
-        return fullURL
+        
+        // Add prompt parameter if needed
+        guard var urlComponents = URLComponents(string: fullURL) else {
+            logger.error("Failed to parse legacy URL: \(fullURL)")
+            return fullURL
+        }
+        
+        // Add prompt parameter for legacy flow
+        if let prompt = provider.details.promptValueForConsent {
+            urlComponents.addOrReplaceQueryItem(name: "prompt", value: prompt)
+        }
+        
+        let finalURL = urlComponents.url?.absoluteString ?? fullURL
+        logger.debug("Generated legacy URL for \(provider.rawValue): \(finalURL)")
+        return finalURL
     }
 
     /// Generates an authorization URL for a custom social login provider.


### PR DESCRIPTION
- Detect legacy social login flow when authorizationUrl starts with /identity/resources/auth/v2/user/sso/default/
- Add legacyAuthorizeURL method to generate legacy URLs
- Modify handleSocialLogin to automatically switch to legacy flow when needed
- Maintain backward compatibility with existing configurations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically detect legacy social login providers and fall back to a legacy authorize URL when the modern flow isn’t available.
> 
> - **Social Login Flow**:
>   - Detect legacy providers by checking `authorizationUrl` that start with `/identity/resources/auth/v2/user/sso/default/` in `SocialLoginUrlGenerator.authorizeURL(for:)`, signaling fallback by returning `nil`.
>   - Add `legacyAuthorizeURL(for:action:)` to build absolute legacy URLs (including `prompt` when applicable).
>   - Update `FronteggAuth.handleSocialLogin` to automatically switch to legacy flow when the modern URL isn’t generated (non-custom providers), invoking `loginWithSocialLogin` with the legacy URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ba1ec666b185452bce4130ba44134b765a5a142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->