### PR TITLE
FR-22001 - CI CD fixes

### DIFF
--- a/.github/workflows/onPullRequestMerged.yaml
+++ b/.github/workflows/onPullRequestMerged.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
       - name: Git Identity
         run: |

--- a/.github/workflows/onPullRequestMerged.yaml
+++ b/.github/workflows/onPullRequestMerged.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Git Identity
         run: |
@@ -122,10 +124,9 @@ jobs:
 
       - name: Create Release Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3.5.1
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ secrets.GITHUB_WORKSPACE }}
           commit-message: "Update v${{ steps.incremented-version.outputs.result }}"
           committer: GitHub <noreply@github.com>
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"

--- a/.github/workflows/onPullRequestMerged.yaml
+++ b/.github/workflows/onPullRequestMerged.yaml
@@ -125,6 +125,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ secrets.GITHUB_WORKSPACE }}
           commit-message: "Update v${{ steps.incremented-version.outputs.result }}"
           committer: GitHub <noreply@github.com>
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to CI workflow behavior, but it could affect automated release PR creation if the action’s v8 defaults/inputs differ from v3.5.1.
> 
> **Overview**
> Updates the release automation workflow to use `peter-evans/create-pull-request@v8` instead of `v3.5.1` when creating the post-merge release pull request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce0385e08fd48f4dd43c6dc7afd04bd79b04090b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->