### PR TITLE
FR-22001 - Enhance offline mode support and social login flow handling

### DIFF
--- a/.github/scripts/reset_swiftpm_artifact_cache.sh
+++ b/.github/scripts/reset_swiftpm_artifact_cache.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_cache_dir="${HOME}/Library/Caches/org.swift.swiftpm/artifacts"
+
+if [ -d "${artifact_cache_dir}" ]; then
+  rm -rf "${artifact_cache_dir}"
+fi

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
       - name: Run Unit Tests
         run: |
           set -o pipefail
@@ -36,6 +39,7 @@ jobs:
             -only-testing:FronteggSwiftTests \
             -resultBundlePath "$RUNNER_TEMP/unit-tests.xcresult" \
             -enableCodeCoverage YES \
+            -parallel-testing-enabled NO \
             2>&1 | tee "$RUNNER_TEMP/unit-tests.log"
 
       - name: Upload unit test artifacts
@@ -77,6 +81,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
 
       - name: Run ${{ matrix.app }} E2E tests (shard ${{ matrix.shard-index }}/${{ matrix.shard-total }})
         run: |

--- a/.github/workflows/onPullRequestUpdated.yaml
+++ b/.github/workflows/onPullRequestUpdated.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
       - name: Build for Testing
         run: |
           xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
       - name: Check Xcode setup
         run: |
           xcodebuild -project demo/demo.xcodeproj -version

--- a/.github/workflows/onReleaseMerged.yaml
+++ b/.github/workflows/onReleaseMerged.yaml
@@ -21,6 +21,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
       - name: Git Identity
         run: |
           git config --global user.name 'frontegg'

--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -54,6 +54,10 @@ public class FronteggAuth: FronteggState {
     // internal for extension access (Refresh, Testing, Connectivity)
     var refreshTokenDispatch: DispatchWorkItem?
     var offlineDebounceWork: DispatchWorkItem?
+    let connectivityGenerationLock = NSLock()
+    var connectivityGeneration: UInt64 = 0
+    let logoutTransitionLock = NSLock()
+    var logoutInProgress = false
     // internal for extension access (FronteggAuth+Connectivity.swift)
     let offlineDebounceDelay: TimeInterval = 0.6
     let scheduledRefreshDeferredRetryDelay: TimeInterval = 1.0
@@ -65,6 +69,8 @@ public class FronteggAuth: FronteggState {
     var networkMonitoringToken: NetworkStatusMonitor.OnChangeToken?
     // internal for extension access (FronteggAuth+OAuthErrors.swift)
     var pendingOAuthErrorContext: FronteggOAuthErrorContext?
+    var pendingOAuthErrorPresentationMode: FronteggOAuthErrorPresentation?
+    var pendingOAuthErrorDelegateBox: FronteggWeakOAuthErrorDelegateBox?
     var pendingOAuthErrorPresentationWorkItem: DispatchWorkItem?
     var pendingEmbeddedOAuthErrorFallbackWorkItem: DispatchWorkItem?
     let oauthErrorPresentationDelay: TimeInterval = 0.35

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -43,11 +43,12 @@ extension FronteggAuth {
     }
 
     func stopOfflineMonitoring() {
-        NetworkStatusMonitor.stopBackgroundMonitoring()
-        if let token = self.networkMonitoringToken {
+        let token = self.networkMonitoringToken
+        self.networkMonitoringToken = nil
+        if let token {
             NetworkStatusMonitor.removeOnChange(token)
-            self.networkMonitoringToken = nil
         }
+        NetworkStatusMonitor.stopBackgroundMonitoring()
     }
 
     func invalidateConnectivityObservers() {
@@ -504,12 +505,15 @@ extension FronteggAuth {
         DispatchQueue.global(qos: .background).async {
 
             Task {
-                guard await NetworkStatusMonitor.isActive else {
-                    self.logger.info("No network connection")
-                    return
-                }
-
                 if self.isOfflineMode {
+                    let networkAvailable = await NetworkStatusMonitor.probeConfiguredReachability(
+                        timeout: self.unauthenticatedStartupProbeTimeout
+                    )
+                    guard networkAvailable else {
+                        self.logger.info("No network connection")
+                        return
+                    }
+
                     let hasRuntimeSession = self.isAuthenticated
                         || self.accessToken != nil
                         || self.refreshToken != nil
@@ -534,6 +538,11 @@ extension FronteggAuth {
 
                     self.logger.info("Network is back, settling offline state through reconnect handling")
                     self.reconnectedToInternet()
+                    return
+                }
+
+                guard await NetworkStatusMonitor.isActive else {
+                    self.logger.info("No network connection")
                     return
                 }
 

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -23,12 +23,54 @@ extension FronteggAuth {
         self.warmingWebViewAsync()
     }
 
-    public func reconnectedToInternet() {
+    @discardableResult
+    func advanceConnectivityGeneration() -> UInt64 {
+        connectivityGenerationLock.withLock {
+            connectivityGeneration &+= 1
+            return connectivityGeneration
+        }
+    }
+
+    func isConnectivityGenerationCurrent(_ generation: UInt64) -> Bool {
+        connectivityGenerationLock.withLock {
+            connectivityGeneration == generation
+        }
+    }
+
+    func cancelPendingOfflineDebounce() {
+        offlineDebounceWork?.cancel()
+        offlineDebounceWork = nil
+    }
+
+    func stopOfflineMonitoring() {
+        NetworkStatusMonitor.stopBackgroundMonitoring()
+        if let token = self.networkMonitoringToken {
+            NetworkStatusMonitor.removeOnChange(token)
+            self.networkMonitoringToken = nil
+        }
+    }
+
+    func invalidateConnectivityObservers() {
+        cancelPendingOfflineDebounce()
+        _ = advanceConnectivityGeneration()
+    }
+
+    func clearTransientConnectivityStateAfterAuthenticatedSuccess() {
+        invalidateConnectivityObservers()
+        stopOfflineMonitoring()
+        lastAttemptReason = nil
+    }
+
+    public func reconnectedToInternet(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration,
+           !isConnectivityGenerationCurrent(expectedGeneration) {
+            return
+        }
+
         // Always cancel a pending debounced offline transition first.
         // Quick reconnects during startup can otherwise leave a stale work item
         // that flips `isOfflineMode` to true after reachability has already recovered.
-        offlineDebounceWork?.cancel()
-        offlineDebounceWork = nil
+        cancelPendingOfflineDebounce()
 
         if(self.isOfflineMode == false){
             return;
@@ -46,13 +88,19 @@ extension FronteggAuth {
             await self.startPostConnectivityServices()
         }
     }
-    public func disconnectedFromInternet() {
+    public func disconnectedFromInternet(expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration,
+           !isConnectivityGenerationCurrent(expectedGeneration) {
+            return
+        }
 
         self.logger.info("Disconnected from the internet (debounced)")
         // Debounce setting offline to avoid brief flicker on quick reconnects
-        offlineDebounceWork?.cancel()
+        cancelPendingOfflineDebounce()
+        let generation = expectedGeneration ?? connectivityGenerationLock.withLock { connectivityGeneration }
         let work = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
+            guard self.isConnectivityGenerationCurrent(generation) else { return }
             // Only set offline if still disconnected (best effort via lastAttemptReason or state)
             // We rely on reconnectedToInternet() to cancel this when path is back.
             self.setIsOfflineMode(true)
@@ -428,18 +476,16 @@ extension FronteggAuth {
         let monitoringInterval = intervalOverride ?? config?.networkMonitoringInterval ?? 10
 
         // Stop existing monitoring to avoid duplicates
-        NetworkStatusMonitor.stopBackgroundMonitoring()
-        if let token = self.networkMonitoringToken {
-            NetworkStatusMonitor.removeOnChange(token)
-            self.networkMonitoringToken = nil
-        }
+        stopOfflineMonitoring()
+        cancelPendingOfflineDebounce()
+        let generation = advanceConnectivityGeneration()
 
         let token = NetworkStatusMonitor.addOnChangeReturningToken { [weak self] reachable in
             guard let self = self else { return }
             if reachable {
-                self.reconnectedToInternet()
+                self.reconnectedToInternet(expectedGeneration: generation)
             } else {
-                self.disconnectedFromInternet()
+                self.disconnectedFromInternet(expectedGeneration: generation)
             }
         }
         self.networkMonitoringToken = token

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -508,7 +508,61 @@ extension FronteggAuth {
                     self.logger.info("No network connection")
                     return
                 }
-                self.logger.info("Netowrk is back, refreshing...")
+
+                if self.isOfflineMode {
+                    let hasRuntimeSession = self.isAuthenticated
+                        || self.accessToken != nil
+                        || self.refreshToken != nil
+
+                    if !hasRuntimeSession {
+                        self.logger.info("Network is back, clearing unauthenticated offline state")
+                        self.cancelPendingOfflineDebounce()
+                        self.lastAttemptReason = nil
+                        await MainActor.run {
+                            self.setUser(nil)
+                            self.setIsOfflineMode(false)
+                            self.setIsLoading(false)
+                            self.setWebLoading(false)
+                            self.setInitializing(false)
+                            self.setShowLoader(false)
+                            self.setAppLink(false)
+                            self.setExternalLink(false)
+                        }
+                        return
+                    }
+
+                    let config = try? PlistHelper.fronteggConfig()
+                    let storedArtifacts = self.resolveStoredSessionArtifacts(
+                        enableSessionPerTenant: config?.enableSessionPerTenant ?? false
+                    )
+                    let hasStoredTokens = self.accessToken != nil
+                        || self.refreshToken != nil
+                        || storedArtifacts.accessToken != nil
+                        || storedArtifacts.refreshToken != nil
+
+                    if !hasStoredTokens && !self.isAuthenticated {
+                        self.logger.info("Network is back, clearing unauthenticated offline state")
+                        self.cancelPendingOfflineDebounce()
+                        self.lastAttemptReason = nil
+                        await MainActor.run {
+                            self.setUser(nil)
+                            self.setIsOfflineMode(false)
+                            self.setIsLoading(false)
+                            self.setWebLoading(false)
+                            self.setInitializing(false)
+                            self.setShowLoader(false)
+                            self.setAppLink(false)
+                            self.setExternalLink(false)
+                        }
+                        return
+                    }
+
+                    self.logger.info("Network is back, settling offline state through reconnect handling")
+                    self.reconnectedToInternet()
+                    return
+                }
+
+                self.logger.info("Network is back, refreshing...")
                 _ = await self.refreshTokenIfNeeded()
             }
         }

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -531,32 +531,6 @@ extension FronteggAuth {
                         return
                     }
 
-                    let config = try? PlistHelper.fronteggConfig()
-                    let storedArtifacts = self.resolveStoredSessionArtifacts(
-                        enableSessionPerTenant: config?.enableSessionPerTenant ?? false
-                    )
-                    let hasStoredTokens = self.accessToken != nil
-                        || self.refreshToken != nil
-                        || storedArtifacts.accessToken != nil
-                        || storedArtifacts.refreshToken != nil
-
-                    if !hasStoredTokens && !self.isAuthenticated {
-                        self.logger.info("Network is back, clearing unauthenticated offline state")
-                        self.cancelPendingOfflineDebounce()
-                        self.lastAttemptReason = nil
-                        await MainActor.run {
-                            self.setUser(nil)
-                            self.setIsOfflineMode(false)
-                            self.setIsLoading(false)
-                            self.setWebLoading(false)
-                            self.setInitializing(false)
-                            self.setShowLoader(false)
-                            self.setAppLink(false)
-                            self.setExternalLink(false)
-                        }
-                        return
-                    }
-
                     self.logger.info("Network is back, settling offline state through reconnect handling")
                     self.reconnectedToInternet()
                     return

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -516,7 +516,8 @@ extension FronteggAuth {
 
                     if !hasRuntimeSession {
                         self.logger.info("Network is back, clearing unauthenticated offline state")
-                        self.cancelPendingOfflineDebounce()
+                        self.invalidateConnectivityObservers()
+                        self.stopOfflineMonitoring()
                         self.lastAttemptReason = nil
                         await MainActor.run {
                             self.setUser(nil)

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -502,7 +502,7 @@ extension FronteggAuth {
 
     public func recheckConnection() {
 
-        DispatchQueue.global(qos: .background).async {
+        DispatchQueue.global(qos: .userInitiated).async {
 
             Task {
                 if self.isOfflineMode {

--- a/Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift
@@ -231,6 +231,9 @@ extension FronteggAuth {
             let accessTokenToSet = accessToken
             let refreshTokenToSet = refreshToken
             let shouldEnterOfflineMode = hydrationMode == .preserveCachedOrDerivedUser
+            if !shouldEnterOfflineMode {
+                clearTransientConnectivityStateAfterAuthenticatedSuccess()
+            }
             await MainActor.run {
                 setRefreshToken(refreshTokenToSet)
                 setAccessToken(accessTokenToSet)

--- a/Sources/FronteggSwift/auth/FronteggAuth+Logout.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Logout.swift
@@ -9,8 +9,55 @@ import WebKit
 
 extension FronteggAuth {
 
+    private func finalizeLoggedOutOfflineState(
+        enableOfflineMode: Bool,
+        preserveOfflineState: Bool
+    ) async {
+        guard enableOfflineMode else {
+            await MainActor.run {
+                self.setIsOfflineMode(false)
+            }
+            return
+        }
+
+        if preserveOfflineState {
+            await MainActor.run {
+                self.setIsOfflineMode(true)
+            }
+            self.logger.info("Logout preserved unauthenticated offline mode from the previous authenticated offline state")
+            ensureOfflineMonitoringActive(emitInitialState: true)
+            return
+        }
+
+        let initialNetworkAvailable = await NetworkStatusMonitor.isActive
+        let settledOnline = await settleUnauthenticatedStartupConnectivity(
+            initialNetworkAvailable: initialNetworkAvailable,
+            debounceDelay: 0.1,
+            recoveryProbeCount: 1,
+            connectivityProbe: { [weak self] in
+                guard let self = self else { return false }
+                return await NetworkStatusMonitor.probeConfiguredReachability(
+                    timeout: self.unauthenticatedStartupProbeTimeout
+                )
+            }
+        )
+
+        self.logger.info(
+            "Logout settled unauthenticated connectivity \(settledOnline ? "online" : "offline")"
+        )
+        ensureOfflineMonitoringActive(emitInitialState: false)
+    }
+
     public func logout(clearCookie: Bool = true, _ completion: FronteggAuth.LogoutHandler? = nil) {
         Task { @MainActor in
+            self.logoutTransitionLock.withLock {
+                self.logoutInProgress = true
+            }
+            defer {
+                self.logoutTransitionLock.withLock {
+                    self.logoutInProgress = false
+                }
+            }
 
             setIsLoading(true)
 
@@ -32,6 +79,14 @@ extension FronteggAuth {
             // This ensures each device maintains its own tenant context even after logout
             let config = try? PlistHelper.fronteggConfig()
             let enableSessionPerTenant = config?.enableSessionPerTenant ?? false
+            let enableOfflineMode = config?.enableOfflineMode ?? false
+            let wasOfflineBeforeLogout = self.isOfflineMode
+
+            // Logout owns the connectivity transition. Stop current monitoring immediately so
+            // stale callbacks cannot race while server logout or cookie cleanup is still running.
+            cancelScheduledTokenRefresh()
+            invalidateConnectivityObservers()
+            stopOfflineMonitoring()
 
             if enableSessionPerTenant {
                 let preservedTenantId = credentialManager.getLastActiveTenantId()
@@ -44,6 +99,7 @@ extension FronteggAuth {
                 self.credentialManager.clear()
             }
             CredentialManager.clearPendingOAuthFlows()
+            SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
 
             await self.serverLogoutWithTimeout(accessToken: accessTokenForServerLogout, refreshToken: refreshTokenForServerLogout)
 
@@ -57,22 +113,16 @@ extension FronteggAuth {
             setRefreshToken(nil)
             setInitializing(false)
             setAppLink(false)
-            setIsOfflineMode(false)
             self.isLoginInProgress = false
             setRefreshingToken(false)
             setIsStepUpAuthorization(false)
             self.lastAttemptReason = nil
             entitlements.clear()
 
-            // Cancel scheduled tasks and stop monitoring
-            cancelScheduledTokenRefresh()
-            offlineDebounceWork?.cancel()
-            offlineDebounceWork = nil
-            NetworkStatusMonitor.stopBackgroundMonitoring()
-            if let token = self.networkMonitoringToken {
-                NetworkStatusMonitor.removeOnChange(token)
-                self.networkMonitoringToken = nil
-            }
+            await self.finalizeLoggedOutOfflineState(
+                enableOfflineMode: enableOfflineMode,
+                preserveOfflineState: wasOfflineBeforeLogout
+            )
 
             setIsLoading(false)
             completion?(.success(true))

--- a/Sources/FronteggSwift/auth/FronteggAuth+OAuthCallbacks.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+OAuthCallbacks.swift
@@ -108,7 +108,10 @@ extension FronteggAuth {
         Task {
             // Use provided redirectUri or generate default one.
             // For magic link flow, use the redirectUri from the callback URL.
-            let redirectUri = redirectUri ?? generateRedirectUri()
+            let redirectUri = redirectUri ?? generateRedirectUri(
+                baseUrl: self.baseUrl,
+                bundleIdentifier: currentAppBundleIdentifier()
+            )
 
             await MainActor.run {
                 self.setIsLoading(true)
@@ -542,16 +545,11 @@ extension FronteggAuth {
     }
 
     func matchesGeneratedRedirectUri(_ url: URL) -> Bool {
-        guard
-            let expected = URLComponents(string: generateRedirectUri()),
-            let actual = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        else {
-            return false
-        }
-
-        return actual.scheme == expected.scheme
-            && actual.host == expected.host
-            && actual.path == expected.path
+        matchedGeneratedRedirectUri(
+            url,
+            baseUrl: self.baseUrl,
+            bundleIdentifier: currentAppBundleIdentifier()
+        ) != nil
     }
 
     internal func createOauthCallbackHandler(
@@ -602,6 +600,11 @@ extension FronteggAuth {
             }
 
             let oauthState = queryItems["state"]
+            let resolvedRedirectUriOverride = matchedGeneratedRedirectUri(
+                url,
+                baseUrl: self.baseUrl,
+                bundleIdentifier: currentAppBundleIdentifier()
+            ) ?? redirectUriOverride
 
             if let failureDetails = self.oauthFailureDetails(from: queryItems) {
                 clearRelevantPendingOAuthState(callbackState: oauthState)
@@ -658,7 +661,7 @@ extension FronteggAuth {
                 code,
                 codeVerifier,
                 oauthState: oauthState,
-                redirectUri: redirectUriOverride,
+                redirectUri: resolvedRedirectUriOverride,
                 flow: flow,
                 completePendingFlowOnSuccess: true,
                 matchedPendingOAuthState: resolution.source == .stateMatch,

--- a/Sources/FronteggSwift/auth/FronteggAuth+OAuthCallbacks.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+OAuthCallbacks.swift
@@ -100,6 +100,10 @@ extension FronteggAuth {
         matchedPendingOAuthState: Bool = false,
         completion: @escaping FronteggAuth.CompletionHandler
     ) {
+        func clearPendingSocialVerifierIfNeeded() {
+            guard flow == .socialLogin else { return }
+            SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
+        }
 
         Task {
             // Use provided redirectUri or generate default one.
@@ -141,6 +145,7 @@ extension FronteggAuth {
                     matchedPendingOAuthState: matchedPendingOAuthState,
                     managePendingOAuthFlow: completePendingFlowOnSuccess
                 )
+                clearPendingSocialVerifierIfNeeded()
                 self.reportOAuthFailure(error: error, flow: flow)
                 await MainActor.run {
                     self.isLoginInProgress = false
@@ -160,6 +165,7 @@ extension FronteggAuth {
                     matchedPendingOAuthState: matchedPendingOAuthState,
                     managePendingOAuthFlow: completePendingFlowOnSuccess
                 )
+                clearPendingSocialVerifierIfNeeded()
                 self.reportOAuthFailure(error: authError, flow: flow)
                 await MainActor.run {
                     self.isLoginInProgress = false
@@ -189,6 +195,7 @@ extension FronteggAuth {
                         matchedPendingOAuthState: matchedPendingOAuthState,
                         managePendingOAuthFlow: completePendingFlowOnSuccess
                     )
+                    clearPendingSocialVerifierIfNeeded()
                     self.reportOAuthFailure(error: authError, flow: flow)
                     await MainActor.run {
                         self.isLoginInProgress = false
@@ -210,6 +217,7 @@ extension FronteggAuth {
                     matchedPendingOAuthState: matchedPendingOAuthState,
                     completePendingFlowOnSuccess: completePendingFlowOnSuccess
                 )
+                clearPendingSocialVerifierIfNeeded()
 
                 // Call completion on main thread to avoid race conditions
                 // This ensures the completion handler always runs on the main thread
@@ -250,6 +258,7 @@ extension FronteggAuth {
                             matchedPendingOAuthState: matchedPendingOAuthState,
                             managePendingOAuthFlow: completePendingFlowOnSuccess
                         )
+                        clearPendingSocialVerifierIfNeeded()
                         self.reportOAuthFailure(error: authError, flow: flow)
                         await MainActor.run {
                             self.isLoginInProgress = false
@@ -278,6 +287,7 @@ extension FronteggAuth {
                             matchedPendingOAuthState: matchedPendingOAuthState,
                             managePendingOAuthFlow: completePendingFlowOnSuccess
                         )
+                        clearPendingSocialVerifierIfNeeded()
                         self.reportOAuthFailure(error: authError, flow: flow)
                         await MainActor.run {
                             self.isLoginInProgress = false
@@ -297,6 +307,7 @@ extension FronteggAuth {
                         matchedPendingOAuthState: matchedPendingOAuthState,
                         completePendingFlowOnSuccess: completePendingFlowOnSuccess
                     )
+                    clearPendingSocialVerifierIfNeeded()
                     await MainActor.run {
                         self.isLoginInProgress = false
                         self.setWebLoading(false)
@@ -310,6 +321,7 @@ extension FronteggAuth {
                         matchedPendingOAuthState: matchedPendingOAuthState,
                         managePendingOAuthFlow: completePendingFlowOnSuccess
                     )
+                    clearPendingSocialVerifierIfNeeded()
                     self.reportOAuthFailure(error: authError, flow: flow)
                     await MainActor.run {
                         self.isLoginInProgress = false

--- a/Sources/FronteggSwift/auth/FronteggAuth+OAuthErrors.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+OAuthErrors.swift
@@ -193,12 +193,17 @@ extension FronteggAuth {
             flow: flow,
             embeddedMode: embeddedMode ?? self.embeddedMode
         )
+        let presentationMode = FronteggOAuthErrorRuntimeSettings.presentation
+        let delegateBox = FronteggWeakOAuthErrorDelegateBox()
+        delegateBox.value = FronteggOAuthErrorRuntimeSettings.delegateBox.value
 
         Task { @MainActor in
             FronteggRuntime.testingLog(
                 "E2E queued OAuth error flow=\(context.flow) embedded=\(context.embeddedMode) code=\(context.errorCode ?? "nil") message=\(context.displayMessage)"
             )
             self.pendingOAuthErrorContext = context
+            self.pendingOAuthErrorPresentationMode = presentationMode
+            self.pendingOAuthErrorDelegateBox = delegateBox
             let shouldDeferEmbeddedPresentation = context.embeddedMode && self.webview != nil
             if shouldDeferEmbeddedPresentation {
                 self.pendingOAuthErrorPresentationWorkItem?.cancel()
@@ -215,8 +220,9 @@ extension FronteggAuth {
 
     @MainActor
     func flushPendingOAuthErrorPresentationIfNeeded(delayIfNeeded: Bool = false) {
+        let presentationMode = pendingOAuthErrorPresentationMode ?? FronteggOAuthErrorRuntimeSettings.presentation
         let requiresForegroundWindow =
-            FronteggOAuthErrorRuntimeSettings.presentation == .toast
+            presentationMode == .toast
 
         guard !requiresForegroundWindow || UIApplication.shared.applicationState != .background else {
             return
@@ -225,17 +231,24 @@ extension FronteggAuth {
         guard let context = pendingOAuthErrorContext else {
             pendingEmbeddedOAuthErrorFallbackWorkItem?.cancel()
             pendingEmbeddedOAuthErrorFallbackWorkItem = nil
+            pendingOAuthErrorPresentationMode = nil
+            pendingOAuthErrorDelegateBox = nil
             return
         }
 
         pendingEmbeddedOAuthErrorFallbackWorkItem?.cancel()
         pendingEmbeddedOAuthErrorFallbackWorkItem = nil
+        let delegateBox = pendingOAuthErrorDelegateBox
         pendingOAuthErrorContext = nil
+        pendingOAuthErrorPresentationMode = nil
+        pendingOAuthErrorDelegateBox = nil
         FronteggRuntime.testingLog(
             "E2E flushing OAuth error flow=\(context.flow) embedded=\(context.embeddedMode) delay=\(delayIfNeeded)"
         )
         scheduleOAuthErrorPresentation(
             context,
+            presentation: presentationMode,
+            delegateBox: delegateBox,
             delay: delayIfNeeded ? oauthErrorPresentationDelay : 0
         )
     }
@@ -243,22 +256,24 @@ extension FronteggAuth {
     @MainActor
     func scheduleOAuthErrorPresentation(
         _ context: FronteggOAuthErrorContext,
+        presentation: FronteggOAuthErrorPresentation,
+        delegateBox: FronteggWeakOAuthErrorDelegateBox?,
         delay: TimeInterval
     ) {
         pendingOAuthErrorPresentationWorkItem?.cancel()
 
         let shouldPresentImmediately =
-            delay <= 0 && FronteggOAuthErrorRuntimeSettings.presentation == .delegate
+            delay <= 0 && presentation == .delegate
         if shouldPresentImmediately {
             pendingOAuthErrorPresentationWorkItem = nil
-            presentOAuthError(context)
+            presentOAuthError(context, presentation: presentation, delegateBox: delegateBox)
             return
         }
 
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.pendingOAuthErrorPresentationWorkItem = nil
-            self.presentOAuthError(context)
+            self.presentOAuthError(context, presentation: presentation, delegateBox: delegateBox)
         }
 
         pendingOAuthErrorPresentationWorkItem = workItem
@@ -307,11 +322,15 @@ extension FronteggAuth {
     }
 
     @MainActor
-    func presentOAuthError(_ context: FronteggOAuthErrorContext) {
+    func presentOAuthError(
+        _ context: FronteggOAuthErrorContext,
+        presentation: FronteggOAuthErrorPresentation,
+        delegateBox: FronteggWeakOAuthErrorDelegateBox?
+    ) {
         FronteggRuntime.testingLog(
             "E2E presenting OAuth error flow=\(context.flow) embedded=\(context.embeddedMode) message=\(context.displayMessage)"
         )
-        switch FronteggOAuthErrorRuntimeSettings.presentation {
+        switch presentation {
         case .toast:
             let window = self.resolveOAuthErrorPresentationWindow()
             if window == nil {
@@ -319,7 +338,7 @@ extension FronteggAuth {
             }
             FronteggOAuthToastPresenter.shared.show(message: context.displayMessage, in: window)
         case .delegate:
-            FronteggOAuthErrorRuntimeSettings.delegateBox.value?.fronteggSDK(didReceiveOAuthError: context)
+            delegateBox?.value?.fronteggSDK(didReceiveOAuthError: context)
         }
     }
 

--- a/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
@@ -283,6 +283,11 @@ extension FronteggAuth {
 
                         // After initialization, handle normal token changes
                         if accessToken != nil {
+                            // If the generation changed since we captured it, another
+                            // transition already owns the connectivity state — skip.
+                            guard self.isConnectivityGenerationCurrent(capturedGeneration) else {
+                                return
+                            }
                             // Token was set - ensure monitoring is stopped
                             self.clearTransientConnectivityStateAfterAuthenticatedSuccess()
                         } else {

--- a/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
@@ -274,9 +274,13 @@ extension FronteggAuth {
                 .dropFirst(dropCount)
                 .sink { [weak self] accessToken in
                     guard let self = self else { return }
+                    // Capture generation before async dispatch so we can detect stale
+                    // callbacks (e.g. logout advancing the generation while this dispatch
+                    // is still queued).
+                    let capturedGeneration = self.connectivityGenerationLock.withLock { self.connectivityGeneration }
                     DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                         guard let self = self else { return }
-                        
+
                         // After initialization, handle normal token changes
                         if accessToken != nil {
                             // Token was set - ensure monitoring is stopped
@@ -284,6 +288,12 @@ extension FronteggAuth {
                         } else {
                             let logoutInProgress = self.logoutTransitionLock.withLock { self.logoutInProgress }
                             if logoutInProgress {
+                                return
+                            }
+
+                            // If the generation changed since we captured it, another
+                            // transition (e.g. logout) already set up monitoring — skip.
+                            guard self.isConnectivityGenerationCurrent(capturedGeneration) else {
                                 return
                             }
 

--- a/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
@@ -280,25 +280,24 @@ extension FronteggAuth {
                         // After initialization, handle normal token changes
                         if accessToken != nil {
                             // Token was set - ensure monitoring is stopped
-                            NetworkStatusMonitor.stopBackgroundMonitoring()
-                            if let token = self.networkMonitoringToken {
-                                NetworkStatusMonitor.removeOnChange(token)
-                                self.networkMonitoringToken = nil
-                            }
+                            self.clearTransientConnectivityStateAfterAuthenticatedSuccess()
                         } else {
-                            // Token was cleared - start monitoring
-                            NetworkStatusMonitor.stopBackgroundMonitoring()
-                            if let token = self.networkMonitoringToken {
-                                NetworkStatusMonitor.removeOnChange(token)
-                                self.networkMonitoringToken = nil
+                            let logoutInProgress = self.logoutTransitionLock.withLock { self.logoutInProgress }
+                            if logoutInProgress {
+                                return
                             }
+
+                            // Token was cleared - start monitoring
+                            self.stopOfflineMonitoring()
+                            self.cancelPendingOfflineDebounce()
+                            let generation = self.advanceConnectivityGeneration()
                             
                             let token = NetworkStatusMonitor.addOnChangeReturningToken { [weak self] reachable in
                                 guard let self = self else { return }
                                 if reachable {
-                                    self.reconnectedToInternet()
+                                    self.reconnectedToInternet(expectedGeneration: generation)
                                 } else {
-                                    self.disconnectedFromInternet()
+                                    self.disconnectedFromInternet(expectedGeneration: generation)
                                 }
                             }
                             self.networkMonitoringToken = token
@@ -308,11 +307,7 @@ extension FronteggAuth {
                 }.store(in: &subscribers)
             
             if hasTokensInKeychain {
-                NetworkStatusMonitor.stopBackgroundMonitoring()
-                if let token = self.networkMonitoringToken {
-                    NetworkStatusMonitor.removeOnChange(token)
-                    self.networkMonitoringToken = nil
-                }
+                self.stopOfflineMonitoring()
             }
             
             if let _ = refreshToken, let _ = accessToken {
@@ -332,11 +327,7 @@ extension FronteggAuth {
 
         if hasAnySessionArtifacts {
             // Explicitly stop any existing monitoring before setting tokens
-            NetworkStatusMonitor.stopBackgroundMonitoring()
-            if let token = self.networkMonitoringToken {
-                NetworkStatusMonitor.removeOnChange(token)
-                self.networkMonitoringToken = nil
-            }
+            self.clearTransientConnectivityStateAfterAuthenticatedSuccess()
 
             // Set whichever tokens we have
             if let rt = refreshToken { setRefreshToken(rt) }

--- a/Sources/FronteggSwift/auth/FronteggAuth+SocialFlows.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SocialFlows.swift
@@ -23,6 +23,7 @@ extension FronteggAuth {
         errorDescription: String? = nil,
         completion: @escaping FronteggAuth.CompletionHandler
     ) {
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
         DispatchQueue.main.async {
             self.activeEmbeddedOAuthFlow = .login
             self.reportOAuthFailure(
@@ -39,6 +40,7 @@ extension FronteggAuth {
         _ details: OAuthFailureDetails,
         completion: @escaping FronteggAuth.CompletionHandler
     ) {
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
         DispatchQueue.main.async {
             self.activeEmbeddedOAuthFlow = .login
             self.reportOAuthFailure(details: details, flow: .socialLogin)

--- a/Sources/FronteggSwift/auth/FronteggAuth+SocialFlows.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SocialFlows.swift
@@ -138,6 +138,10 @@ extension FronteggAuth {
             return
         }
 
+        // Social login flows are single-flight. Drop any stale verifier state from a
+        // previous abandoned attempt before generating the next authorize URL.
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
+
         let oauthCallback: (URL?, Error?) -> Void = { [weak self] callbackURL, error in
             guard let self else { return }
             self.handleSocialLoginOAuthCallback(

--- a/Sources/FronteggSwift/auth/FronteggAuth+SocialLoginCallback.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SocialLoginCallback.swift
@@ -59,18 +59,7 @@ extension FronteggAuth {
 
         // Process state
         if let state = q("state"), !state.isEmpty {
-            if let data = state.data(using: .utf8),
-               var dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                dict.removeValue(forKey: "platform")
-                dict.removeValue(forKey: "bundleId")
-                if let newData = try? JSONSerialization.data(withJSONObject: dict, options: []),
-                   let newState = String(data: newData, encoding: .utf8) {
-                    queryParams["state"] = newState
-                }
-            } else {
-                // fallback if state is not valid JSON
-                queryParams["state"] = state
-            }
+            queryParams["state"] = SocialLoginUrlGenerator.canonicalizeSocialState(state)
         }
 
         if let s = WebAuthenticator.shared.session {

--- a/Sources/FronteggSwift/auth/FronteggAuth+SocialLoginCallback.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SocialLoginCallback.swift
@@ -15,7 +15,7 @@ extension FronteggAuth {
         }
 
         // 1) Host must match Frontegg base URL host
-        guard let allowedHost = URL(string: FronteggAuth.shared.baseUrl)?.host else {
+        guard let allowedHost = URL(string: self.baseUrl)?.host else {
             return nil
         }
 
@@ -23,15 +23,21 @@ extension FronteggAuth {
             return nil
         }
 
-        // 2) Path: /oauth/account/redirect/ios/{bundleId}/{provider}
-        let prefix = "/oauth/account/redirect/ios/"
-        let path = comps.path
-        guard path.hasPrefix(prefix) || path.hasPrefix("/ios/oauth/callback") else {
+        let bundleId = currentAppBundleIdentifier()
+        guard !bundleId.isEmpty else {
             return nil
         }
 
-        let bundleId = FronteggApp.shared.bundleIdentifier
-        guard !bundleId.isEmpty else {
+        let matchedCallbackRedirectUri = matchedGeneratedRedirectUri(
+            url,
+            baseUrl: self.baseUrl,
+            bundleIdentifier: bundleId
+        )
+
+        // 2) Path: /oauth/account/redirect/ios/{bundleId}/{provider}
+        let prefix = "/oauth/account/redirect/ios/"
+        let path = comps.path
+        guard path.hasPrefix(prefix) || matchedCallbackRedirectUri != nil else {
             return nil
         }
 
@@ -54,7 +60,8 @@ extension FronteggAuth {
             queryParams["id_token"] = idToken
         }
 
-        let redirectUri = SocialLoginUrlGenerator.shared.defaultRedirectUri()
+        let redirectUri = matchedCallbackRedirectUri
+            ?? generateRedirectUri(baseUrl: self.baseUrl, bundleIdentifier: bundleId)
         queryParams["redirectUri"] = redirectUri
 
         // Process state
@@ -70,7 +77,7 @@ extension FronteggAuth {
         var compsOut = URLComponents()
         compsOut.queryItems = queryParams.map { URLQueryItem(name: $0.key, value: $0.value) }
 
-        let finalUrl = URL(string: "\(FronteggAuth.shared.baseUrl)/oauth/account/social/success?\(compsOut.query ?? "")")
+        let finalUrl = URL(string: "\(self.baseUrl)/oauth/account/social/success?\(compsOut.query ?? "")")
 
         return finalUrl
     }

--- a/Sources/FronteggSwift/auth/FronteggAuth+Testing.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Testing.swift
@@ -34,13 +34,24 @@ extension FronteggAuth {
         activeEmbeddedOAuthFlow = .login
         loginHint = nil
         loginCompletion = nil
+        pendingOAuthErrorPresentationWorkItem?.cancel()
+        pendingOAuthErrorPresentationWorkItem = nil
+        pendingEmbeddedOAuthErrorFallbackWorkItem?.cancel()
+        pendingEmbeddedOAuthErrorFallbackWorkItem = nil
+        pendingOAuthErrorContext = nil
+        pendingOAuthErrorPresentationMode = nil
+        pendingOAuthErrorDelegateBox = nil
         lastAttemptReason = nil
         webview = nil
         Self.testNetworkPathAvailabilityOverride = nil
+        logoutTransitionLock.withLock {
+            logoutInProgress = false
+        }
 
         credentialManager.deleteLastActiveTenantId()
         credentialManager.clear()
         CredentialManager.clearPendingOAuthFlows()
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
         UserDefaults.standard.removeObject(forKey: KeychainKeys.region.rawValue)
 
         setIsAuthenticated(false)

--- a/Sources/FronteggSwift/authenticators/WebAuthenticator.swift
+++ b/Sources/FronteggSwift/authenticators/WebAuthenticator.swift
@@ -48,7 +48,7 @@ class WebAuthenticator: NSObject, ObservableObject, ASWebAuthenticationPresentat
         testingSession = nil
 #endif
         
-        let bundleIdentifier = FronteggApp.shared.bundleIdentifier
+        let bundleIdentifier = currentAppBundleIdentifier()
 
         #if DEBUG
         if FronteggRuntime.allowsTestingWebAuthenticationTransport {

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -26,7 +26,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private var previousUrl: URL? = nil
     private var isSocialLoginFlow: Bool = false
     private var socialSuccessWatchdogWorkItem: DispatchWorkItem? = nil
-    private let socialSuccessWatchdogDelay: TimeInterval = 1.25
+    private let socialSuccessWatchdogDelay: TimeInterval = 5.0
+    private var socialSuccessRetryCount: Int = 0
+    private let socialSuccessMaxRetries: Int = 2
 
     func setActiveOAuthFlow(_ flow: FronteggOAuthFlow) {
         fronteggAuth.activeEmbeddedOAuthFlow = flow
@@ -74,32 +76,46 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private func cancelSocialSuccessWatchdog() {
         socialSuccessWatchdogWorkItem?.cancel()
         socialSuccessWatchdogWorkItem = nil
+        socialSuccessRetryCount = 0
     }
 
     private func scheduleSocialSuccessWatchdog(for webView: WKWebView, url: URL) {
         cancelSocialSuccessWatchdog()
 
         let workItem = DispatchWorkItem { [weak self, weak webView] in
-            guard let self = self else { return }
-            let currentUrl = webView?.url ?? url
+            guard let self = self, let webView = webView else { return }
+            let currentUrl = webView.url ?? url
 
             guard currentUrl.path.contains("/oauth/account/social/success") else {
                 return
             }
 
-            // The social success page is still showing after the timeout. This means
-            // the server-side code exchange (e.g. Google → Frontegg) either failed or
-            // is still in progress. The page may contain an error message that the
-            // loading overlay is hiding. Hide the loader so the user can see the
-            // server's response. Do NOT extract the provider code and send it to
-            // /oauth/token — that endpoint expects a Frontegg authorization code,
-            // not a provider code.
-            self.logger.warning(
-                "Social login success page stalled, hiding loader to reveal server response for \(currentUrl.absoluteString)"
-            )
-            DispatchQueue.main.async { [weak self] in
-                self?.fronteggAuth.setWebLoading(false)
-                self?.fronteggAuth.setLoginBoxLoading(false)
+            // The social success page is still showing after the timeout. The
+            // server-side provider code exchange (e.g. Google → Frontegg) either
+            // failed or stalled. Do NOT extract the provider code and send it to
+            // /oauth/token — that endpoint expects a Frontegg authorization code.
+            // Instead, retry by reloading the page so the server can re-attempt
+            // the exchange. After max retries, hide the loader to reveal any
+            // server-rendered error message.
+            if self.socialSuccessRetryCount < self.socialSuccessMaxRetries {
+                self.socialSuccessRetryCount += 1
+                self.logger.warning(
+                    "Social login success page stalled (attempt \(self.socialSuccessRetryCount)/\(self.socialSuccessMaxRetries)), reloading to retry server-side exchange"
+                )
+                DispatchQueue.main.async { [weak self, weak webView] in
+                    guard let webView = webView else { return }
+                    webView.reload()
+                    // Re-schedule watchdog for the reload
+                    self?.scheduleSocialSuccessWatchdog(for: webView, url: url)
+                }
+            } else {
+                self.logger.warning(
+                    "Social login success page stalled after \(self.socialSuccessMaxRetries) retries, hiding loader to reveal server response"
+                )
+                DispatchQueue.main.async { [weak self] in
+                    self?.fronteggAuth.setWebLoading(false)
+                    self?.fronteggAuth.setLoginBoxLoading(false)
+                }
             }
         }
 

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -735,9 +735,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                    previousRoutedPath!.contains("/oauth/account/oidc/callback")
                )) {
                 // Check if current URL is a dashboard/tenant selection page
-                let isDashboardOrTenantSelection = url.path.contains("/dashboard") ||
-                                                   url.path.contains("/tenant") ||
-                                                   (url.path == "/" && !url.path.contains("/oauth/") && !url.path.contains("/login"))
+                let isDashboardOrTenantSelection = routedPath.contains("/dashboard") ||
+                                                   routedPath.contains("/tenant") ||
+                                                   (routedPath == "/" && !routedPath.contains("/oauth/") && !routedPath.contains("/login"))
                 
                 if isDashboardOrTenantSelection && url.absoluteString.starts(with: fronteggAuth.baseUrl) {
                     logger.info("Detected redirect to dashboard/tenant selection after social login. Previous URL: \(previousUrl?.absoluteString ?? "nil"), Current URL: \(url.absoluteString)")

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -25,6 +25,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private var magicLinkRedirectUri: String? = nil
     private var previousUrl: URL? = nil
     private var isSocialLoginFlow: Bool = false
+    private var socialSuccessWatchdogWorkItem: DispatchWorkItem? = nil
+    private let socialSuccessWatchdogDelay: TimeInterval = 1.25
 
     func setActiveOAuthFlow(_ flow: FronteggOAuthFlow) {
         fronteggAuth.activeEmbeddedOAuthFlow = flow
@@ -40,6 +42,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     }
 
     private func reloadFreshLoginPage(after delay: TimeInterval = 0) {
+        cancelSocialSuccessWatchdog()
         let (loginUrl, codeVerifier) = AuthorizeUrlGenerator().generate(remainCodeVerifier: true)
         CredentialManager.saveCodeVerifier(codeVerifier)
         fronteggAuth.setWebLoading(true)
@@ -68,13 +71,62 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         return .authError(.codeVerifierNotFound)
     }
 
+    private func cancelSocialSuccessWatchdog() {
+        socialSuccessWatchdogWorkItem?.cancel()
+        socialSuccessWatchdogWorkItem = nil
+    }
+
+    private func scheduleSocialSuccessWatchdog(for webView: WKWebView, url: URL) {
+        cancelSocialSuccessWatchdog()
+
+        let workItem = DispatchWorkItem { [weak self, weak webView] in
+            guard let self = self, let webView = webView else { return }
+            let currentUrl = webView.url ?? url
+            let queryItems = getQueryItems(currentUrl.absoluteString)
+
+            guard currentUrl.path.contains("/oauth/account/social/success") else {
+                return
+            }
+
+            if queryItems?["code"] != nil {
+                self.logger.warning(
+                    "Social login success page stalled, handling callback directly for \(currentUrl.absoluteString)"
+                )
+                DispatchQueue.main.async { [weak self, weak webView] in
+                    guard let self = self, let webView = webView else { return }
+                    webView.stopLoading()
+                    _ = self.handleHostedLoginCallback(webView, currentUrl)
+                }
+                return
+            }
+
+            self.logger.warning(
+                "Social login success page stalled without code, reloading fresh login page"
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadFreshLoginPage()
+            }
+        }
+
+        socialSuccessWatchdogWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + socialSuccessWatchdogDelay, execute: workItem)
+    }
+
     private func isAllowedTestingLoopbackURL(_ url: URL) -> Bool {
         guard FronteggRuntime.isTesting else { return false }
         return url.absoluteString.starts(with: fronteggAuth.baseUrl)
     }
 
-    private func isIOSRedirectPath(_ path: String) -> Bool {
+    private func appRoutePath(for url: URL) -> String {
+        routedAppPath(url, baseUrl: fronteggAuth.baseUrl)
+    }
+
+    private static func isIOSRedirectPath(_ path: String) -> Bool {
         path.range(of: "/oauth/account/redirect/ios/", options: [.caseInsensitive]) != nil
+    }
+
+    private func isIOSRedirectPath(_ path: String) -> Bool {
+        Self.isIOSRedirectPath(path)
     }
 
     private func hasOAuthErrorParameters(_ queryItems: [String: String]?) -> Bool {
@@ -177,6 +229,57 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             hasPendingOAuthStates: resolution.hasPendingOAuthStates
         )
     }
+
+    internal static func resolveHostedCallbackRedirect(
+        url: URL,
+        magicLinkRedirectUri: String?,
+        baseUrl: String,
+        bundleIdentifier: String,
+        embeddedMode: Bool
+    ) -> (redirectUri: String, isMagicLink: Bool) {
+        if Self.isIOSRedirectPath(url.path) {
+            if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                var redirectUriComponents = URLComponents()
+                redirectUriComponents.scheme = urlComponents.scheme
+                redirectUriComponents.host = urlComponents.host
+                redirectUriComponents.path = urlComponents.path
+                if let extractedRedirectUri = redirectUriComponents.url {
+                    return (extractedRedirectUri.absoluteString, true)
+                }
+            }
+
+            let fallbackRedirectUri = magicLinkRedirectUri
+                ?? generateRedirectUri(baseUrl: baseUrl, bundleIdentifier: bundleIdentifier)
+            return (fallbackRedirectUri, true)
+        }
+
+        if url.path.contains("/oauth/account/oidc/callback") {
+            return (
+                generateRedirectUri(baseUrl: baseUrl, bundleIdentifier: bundleIdentifier),
+                false
+            )
+        }
+
+        if url.path.contains("/oauth/account/social/success") && embeddedMode {
+            let queryItems = getQueryItems(url.absoluteString)
+            if let redirectUri = queryItems?["redirectUri"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !redirectUri.isEmpty {
+                return (redirectUri, false)
+            }
+        }
+
+        if let actualRedirectUri = matchedGeneratedRedirectUri(
+            url,
+            baseUrl: baseUrl,
+            bundleIdentifier: bundleIdentifier
+        ) {
+            return (actualRedirectUri, false)
+        }
+
+        let fallbackRedirectUri = magicLinkRedirectUri
+            ?? generateRedirectUri(baseUrl: baseUrl, bundleIdentifier: bundleIdentifier)
+        return (fallbackRedirectUri, magicLinkRedirectUri != nil)
+    }
     
     func webView(
         _ webView: WKWebView,
@@ -244,9 +347,22 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                 logger.trace("Updated previousUrl to: \(currentUrl.absoluteString)")
             }
 
+            let routedPath = appRoutePath(for: url)
+            let previousRoutedPath = previousUrl.map { appRoutePath(for: $0) }
+
+            let matchedGeneratedCallbackUri = matchedGeneratedRedirectUri(
+                url,
+                baseUrl: fronteggAuth.baseUrl,
+                bundleIdentifier: currentAppBundleIdentifier()
+            )
+
+            if !routedPath.contains("/oauth/account/social/success") {
+                cancelSocialSuccessWatchdog()
+            }
+
             if FronteggRuntime.isTesting,
                url.absoluteString.starts(with: fronteggAuth.baseUrl),
-               url.path == "/__frontegg_test/social-login" {
+               routedPath == "/__frontegg_test/social-login" {
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let provider = components?.queryItems?.first(where: { $0.name == "provider" })?.value ?? "google"
                 let custom = components?.queryItems?.first(where: { $0.name == "custom" })?.value == "true"
@@ -275,7 +391,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                 } else {
                     logger.warning("⚠️ Blocking navigation to localhost: \(url.absoluteString)")
                 
-                    if let prevUrl = previousUrl, prevUrl.path.contains("/postlogin/verify") {
+                    if let prevUrl = previousUrl,
+                       (previousRoutedPath?.contains("/postlogin/verify") ?? false) {
                         logger.warning("Detected localhost redirect after /postlogin/verify. Previous URL: \(prevUrl.absoluteString), Current URL: \(url.absoluteString)")
 
                         if let urlComponents = URLComponents(url: prevUrl, resolvingAgainstBaseURL: false),
@@ -315,7 +432,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // This check must be BEFORE custom scheme check to allow OIDC provider navigation
             let urlString = url.absoluteString
             if !urlString.starts(with: fronteggAuth.baseUrl) &&
-               !urlString.starts(with: generateRedirectUri()) &&
+               matchedGeneratedCallbackUri == nil &&
                (urlString.contains("/authorize") || urlString.contains("/oauth/authorize") || 
                 urlString.contains("auth0.com") || urlString.contains("okta.com") || 
                 urlString.contains("login.microsoftonline.com") || urlString.contains("accounts.google.com")) {
@@ -464,13 +581,13 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // This handles other flows that might use different paths
             // These URLs are detected as .loginRoutes but should be handled as HostedLoginCallback
             // EXCEPT for OIDC callback - we need to let the server redirect to custom scheme first
-            if url.path.hasPrefix("/oauth/account/") {
-                logger.info("🔵 [Social Login Debug] OAuth account path detected: \(url.path)")
+            if routedPath.hasPrefix("/oauth/account/") {
+                logger.info("🔵 [Social Login Debug] OAuth account path detected: \(routedPath)")
                 let queryItems = getQueryItems(url.absoluteString)
                 let queryKeys = Array((queryItems ?? [:]).keys).sorted()
                 logger.info("🔵 [Social Login Debug] OAuth account query params: \(queryKeys.joined(separator: ", "))")
                 
-                if url.path.contains("/oauth/account/oidc/callback") {
+                if routedPath.contains("/oauth/account/oidc/callback") {
                     logger.info("🔵 [Social Login Debug] OIDC callback URL detected, allowing server to redirect to custom scheme")
                     logger.info("🔵 [Social Login Debug] OIDC callback URL: \(url.absoluteString)")
                     SentryHelper.addBreadcrumb(
@@ -491,8 +608,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                 }
                 
                 if let queryItems = queryItems, queryItems["code"] != nil {
-                    let isSocialSuccessPath = url.path.contains("/social/success")
-                    if isSocialSuccessPath && FronteggApp.shared.embeddedMode {
+                    let isSocialSuccessPath = routedPath.contains("/social/success")
+                    if isSocialSuccessPath && fronteggAuth.embeddedMode {
                         let previousScheme = previousUrl?.scheme ?? ""
                         let previousWasCustomScheme = !previousScheme.isEmpty && !previousScheme.hasPrefix("http")
                         
@@ -515,11 +632,13 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                             return self.handleHostedLoginCallback(webView, url)
                         } else {
                             logger.info("🔵 [Social Login Debug] /social/success detected as intermediate page (Google case, previousUrl was HTTPS/nil) - allowing normal navigation")
+                            isSocialLoginFlow = true
+                            scheduleSocialSuccessWatchdog(for: webView, url: url)
                             return .allow
                         }
                     }
                     
-                    if url.path.contains("/callback") || url.path.contains("/redirect/") {
+                    if routedPath.contains("/callback") || routedPath.contains("/redirect/") {
                         logger.info("✅ [Social Login Debug] OAuth callback URL with code in /oauth/account/ path, handling as HostedLoginCallback")
                         SentryHelper.addBreadcrumb(
                             "OAuth account callback with code detected",
@@ -554,12 +673,15 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // Check if this is a /postlogin/verify URL
             // IMPORTANT: If the URL has a token parameter (from app link), we must preserve it for device verification
             // Add missing redirect_uri and code_verifier_pkce parameters while preserving the token
-            if url.path.contains("/postlogin/verify") {
+            if routedPath.contains("/postlogin/verify") {
                 if var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
                     var queryItems = urlComponents.queryItems ?? []
                     var needsUpdate = false
                     
-                    let redirectUri = generateRedirectUri()
+                    let redirectUri = generateRedirectUri(
+                        baseUrl: fronteggAuth.baseUrl,
+                        bundleIdentifier: currentAppBundleIdentifier()
+                    )
                     if !queryItems.contains(where: { $0.name == "redirect_uri" }) {
                         queryItems.append(URLQueryItem(name: "redirect_uri", value: redirectUri))
                         needsUpdate = true
@@ -593,10 +715,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // This happens when user already has an active session in Safari
             // After Google auth, server redirects to dashboard instead of callback URL
             if isSocialLoginFlow || 
-               (previousUrl != nil && (
-                   previousUrl!.path.contains("/oauth/account/social/success") ||
-                   isIOSRedirectPath(previousUrl!.path) ||
-                   previousUrl!.path.contains("/oauth/account/oidc/callback")
+               (previousRoutedPath != nil && (
+                   previousRoutedPath!.contains("/oauth/account/social/success") ||
+                   isIOSRedirectPath(previousRoutedPath!) ||
+                   previousRoutedPath!.contains("/oauth/account/oidc/callback")
                )) {
                 // Check if current URL is a dashboard/tenant selection page
                 let isDashboardOrTenantSelection = url.path.contains("/dashboard") ||
@@ -941,7 +1063,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             
             if(urlType == .internalRoutes ) {
                 if url.path.contains("/postlogin/verify") {
-                    let redirectUri = generateRedirectUri()
+                    let redirectUri = generateRedirectUri(
+                        baseUrl: fronteggAuth.baseUrl,
+                        bundleIdentifier: currentAppBundleIdentifier()
+                    )
                     if url.absoluteString.starts(with: redirectUri) {
                         return
                     }
@@ -1151,7 +1276,16 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     
     
     private func handleHostedLoginCallback(_ webView: WKWebView?, _ url: URL) -> WKNavigationActionPolicy {
-        let expectedRedirectUri = generateRedirectUri()
+        cancelSocialSuccessWatchdog()
+        let expectedRedirectUri = generateRedirectUri(
+            baseUrl: fronteggAuth.baseUrl,
+            bundleIdentifier: currentAppBundleIdentifier()
+        )
+        let matchedCallbackRedirectUri = matchedGeneratedRedirectUri(
+            url,
+            baseUrl: fronteggAuth.baseUrl,
+            bundleIdentifier: currentAppBundleIdentifier()
+        )
         logger.info("🔵 [Social Login Debug] Received URL: \(url.absoluteString)")
         logger.info("🔵 [Social Login Debug] Expected redirect_uri: \(expectedRedirectUri)")
         logger.info("🔵 [Social Login Debug] URL scheme: \(url.scheme ?? "nil")")
@@ -1162,7 +1296,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         logger.info("🔵 [Social Login Debug] Magic link redirect URI: \(magicLinkRedirectUri ?? "nil")")
         logger.info("🔵 [Social Login Debug] App URL schemes: \(getAppURLSchemes())")
         logger.info("🔵 [Social Login Debug] Is custom scheme match: \(getAppURLSchemes().contains(url.scheme ?? ""))")
-        logger.info("🔵 [Social Login Debug] URL matches expected redirect URI: \(url.absoluteString.starts(with: expectedRedirectUri))")
+        logger.info("🔵 [Social Login Debug] URL matches expected redirect URI: \(matchedCallbackRedirectUri != nil)")
+        if let matchedCallbackRedirectUri {
+            logger.info("🔵 [Social Login Debug] Matched callback redirect URI: \(matchedCallbackRedirectUri)")
+        }
         
         let queryItems = getQueryItems(url.absoluteString)
         let queryKeys = Array((queryItems ?? [:]).keys).sorted()
@@ -1187,7 +1324,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                 "host": url.host ?? "nil",
                 "path": url.path,
                 "expectedRedirectUri": expectedRedirectUri,
-                "matchesExpected": url.absoluteString.starts(with: expectedRedirectUri),
+                "matchesExpected": matchedCallbackRedirectUri != nil,
+                "matchedRedirectUri": matchedCallbackRedirectUri ?? "nil",
                 "queryKeys": queryKeys,
                 "queryParamCount": allQueryParams.count,
                 "previousUrl": previousUrl?.absoluteString ?? "nil",
@@ -1248,57 +1386,29 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         }
         let oauthState = queryItems?["state"]
         
-        // For magic link and similar flows (forget password, unlock account, invite), the server uses 
-        // an intermediate redirect URL (/oauth/account/redirect/iOS/{bundleId} or /oauth/account/redirect/iOS/{bundleId}/oauth/callback)
-        // We need to use this intermediate URL as redirect_uri for token exchange, not the custom scheme
-        // Check if this is an intermediate redirect callback by examining the URL path
-        var redirectUri: String
-        var isMagicLink: Bool
-        
-        // Check if URL contains /oauth/account/redirect/iOS/ - this indicates an intermediate redirect
-        // (used for magic link, forget password, unlock account, invite flows)
+        let redirectResolution = Self.resolveHostedCallbackRedirect(
+            url: url,
+            magicLinkRedirectUri: magicLinkRedirectUri,
+            baseUrl: fronteggAuth.baseUrl,
+            bundleIdentifier: currentAppBundleIdentifier(),
+            embeddedMode: fronteggAuth.embeddedMode
+        )
+        let redirectUri = redirectResolution.redirectUri
+        let isMagicLink = redirectResolution.isMagicLink
+
         if isIOSRedirectPath(url.path) {
             logger.info("🔵 [Social Login Debug] Detected intermediate redirect URL (magic link flow)")
-            // This is an intermediate redirect callback - extract redirect_uri from the URL itself (without query parameters)
-            isMagicLink = true
-            if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-                var redirectUriComponents = URLComponents()
-                redirectUriComponents.scheme = urlComponents.scheme
-                redirectUriComponents.host = urlComponents.host
-                redirectUriComponents.path = urlComponents.path
-                if let extractedRedirectUri = redirectUriComponents.url {
-                    redirectUri = extractedRedirectUri.absoluteString
-                    logger.info("🔵 [Social Login Debug] Extracted intermediate redirect_uri: \(redirectUri)")
-                } else {
-                    // Fallback to cached value or default
-                    redirectUri = magicLinkRedirectUri ?? generateRedirectUri()
-                    logger.warning("⚠️ [Social Login Debug] Failed to extract redirect_uri from URL, using fallback: \(redirectUri)")
-                }
-            } else {
-                redirectUri = magicLinkRedirectUri ?? generateRedirectUri()
-                logger.warning("⚠️ [Social Login Debug] Failed to parse URL components, using fallback: \(redirectUri)")
-            }
+            logger.info("🔵 [Social Login Debug] Extracted intermediate redirect_uri: \(redirectUri)")
         } else if url.path.contains("/oauth/account/oidc/callback") {
             logger.info("🔵 [Social Login Debug] Detected OIDC callback URL")
-            // OIDC callback - use standard redirect_uri (custom scheme) for token exchange
-            // In hosted mode, ASWebAuthenticationSession callback comes through custom scheme URL
-            // In embedded mode, callback comes through HTTPS URL, but we still need to use standard redirect_uri
-            // The OIDC callback URL is an intermediate redirect from OIDC provider back to Frontegg,
-            // but for token exchange we need to use the original redirect_uri from the authorize request to Frontegg
-            // (the same redirect_uri that was used in the initial authorize request, not the OIDC provider's redirect_uri)
-            isMagicLink = false
-            redirectUri = generateRedirectUri()
             logger.info("🔵 [Social Login Debug] Using standard redirect_uri for OIDC token exchange: \(redirectUri)")
-        } else if url.path.contains("/oauth/account/social/success") && FronteggApp.shared.embeddedMode {
-            logger.info("🔵 [Social Login Debug] Detected social login success callback URL in embedded mode (Microsoft case)")
-            isMagicLink = false
-            redirectUri = generateRedirectUri()
-            logger.info("🔵 [Social Login Debug] Using standard redirect_uri for social login success token exchange (embedded mode): \(redirectUri)")
+        } else if url.path.contains("/oauth/account/social/success") && fronteggAuth.embeddedMode {
+            logger.info("🔵 [Social Login Debug] Detected social login success callback URL in embedded mode")
+            logger.info("🔵 [Social Login Debug] Using callback redirect_uri from social success payload: \(redirectUri)")
+        } else if matchedCallbackRedirectUri != nil {
+            logger.info("🔵 [Social Login Debug] Detected generated callback alias, using actual callback redirect_uri: \(redirectUri)")
         } else {
             logger.info("🔵 [Social Login Debug] Detected regular OAuth callback URL")
-            // Regular OAuth callback - use cached magic link redirect_uri if available, otherwise use standard one
-            redirectUri = magicLinkRedirectUri ?? generateRedirectUri()
-            isMagicLink = magicLinkRedirectUri != nil
             logger.info("🔵 [Social Login Debug] Regular OAuth callback - using redirect_uri: \(redirectUri), isMagicLink: \(isMagicLink)")
         }
         
@@ -1308,7 +1418,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         // Note: We check isMagicLink first (line 819), so magic link flows won't be misidentified as social login
         // Social login is detected by: isSocialLoginFlow flag OR OIDC callback path OR /social/success (embedded mode only, Microsoft case)
         // We don't check for general /oauth/account/ paths to avoid false positives with magic link flows
-        let isSocialLogin = isSocialLoginFlow || url.path.contains("/oauth/account/oidc/callback") || (url.path.contains("/oauth/account/social/success") && FronteggApp.shared.embeddedMode)
+        let isSocialLogin = isSocialLoginFlow || url.path.contains("/oauth/account/oidc/callback") || (url.path.contains("/oauth/account/social/success") && fronteggAuth.embeddedMode)
         let oauthFlow = currentOAuthFlow(defaultingTo: isSocialLogin ? .socialLogin : .login)
         
         logger.info("🔵 [Social Login Debug] Final redirect_uri for token exchange: \(redirectUri)")
@@ -1424,13 +1534,16 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     
     private func setSocialLoginRedirectUri(_ _webView:WKWebView?, _ url:URL) -> WKNavigationActionPolicy {
         let webView = _webView
-        let expectedRedirectUri = generateRedirectUri()
+        let expectedRedirectUri = generateRedirectUri(
+            baseUrl: fronteggAuth.baseUrl,
+            bundleIdentifier: currentAppBundleIdentifier()
+        )
         logger.info("🔵 [Social Login Debug] setSocialLoginRedirectUri called")
         logger.info("🔵 [Social Login Debug] Social login pre-auth URL: \(url.absoluteString)")
         logger.info("🔵 [Social Login Debug] Expected redirect URI to be added: \(expectedRedirectUri)")
         
         let queryItems = [
-            URLQueryItem(name: "redirectUri", value: generateRedirectUri())
+            URLQueryItem(name: "redirectUri", value: expectedRedirectUri)
         ]
         var urlComps = URLComponents(string: url.absoluteString)!
         
@@ -1510,7 +1623,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                         "social_login": [
                             "url": url.absoluteString,
                             "ephemeralSession": ephemeralSession,
-                            "embeddedMode": FronteggApp.shared.embeddedMode,
+                            "embeddedMode": self.fronteggAuth.embeddedMode,
                             "stage": "external_browser_callback"
                         ],
                         "error": [
@@ -1535,7 +1648,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                         "social_login": [
                             "url": url.absoluteString,
                             "ephemeralSession": ephemeralSession,
-                            "embeddedMode": FronteggApp.shared.embeddedMode,
+                            "embeddedMode": self.fronteggAuth.embeddedMode,
                             "stage": "external_browser_callback",
                             "callbackUrl": "nil"
                         ],
@@ -1564,7 +1677,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                             context: [
                                 "social_login": [
                                     "url": url.absoluteString,
-                                    "embeddedMode": FronteggApp.shared.embeddedMode,
+                                    "embeddedMode": self.fronteggAuth.embeddedMode,
                                     "ephemeralSession": ephemeralSession,
                                     "stage": "external_browser_callback",
                                     "callbackUrl": callbackUrl.absoluteString,

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -144,6 +144,15 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                     hasPendingOAuthStates: CredentialManager.hasPendingOAuthStates()
                 )
             } catch {
+                if let verifier = SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: oauthState) {
+                    return HostedCallbackCodeVerifierResolution(
+                        codeVerifier: verifier,
+                        source: "pending_social_state_store",
+                        providerError: error,
+                        hasPendingOAuthStates: CredentialManager.hasPendingOAuthStates()
+                    )
+                }
+
                 let resolution = CredentialManager.resolveCodeVerifier(
                     for: oauthState,
                     allowFallback: true

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -80,7 +80,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     }
 
     private func scheduleSocialSuccessWatchdog(for webView: WKWebView, url: URL) {
-        cancelSocialSuccessWatchdog()
+        // Cancel the pending work item without resetting retryCount
+        // so that retry calls can track cumulative attempts.
+        socialSuccessWatchdogWorkItem?.cancel()
+        socialSuccessWatchdogWorkItem = nil
 
         let workItem = DispatchWorkItem { [weak self, weak webView] in
             guard let self = self, let webView = webView else { return }
@@ -652,6 +655,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                         } else {
                             logger.info("🔵 [Social Login Debug] /social/success detected as intermediate page (Google case, previousUrl was HTTPS/nil) - allowing normal navigation")
                             isSocialLoginFlow = true
+                            socialSuccessRetryCount = 0  // Fresh flow — reset before scheduling
                             scheduleSocialSuccessWatchdog(for: webView, url: url)
                             return .allow
                         }

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -238,14 +238,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         embeddedMode: Bool
     ) -> (redirectUri: String, isMagicLink: Bool) {
         if Self.isIOSRedirectPath(url.path) {
-            if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-                var redirectUriComponents = URLComponents()
-                redirectUriComponents.scheme = urlComponents.scheme
-                redirectUriComponents.host = urlComponents.host
-                redirectUriComponents.path = urlComponents.path
-                if let extractedRedirectUri = redirectUriComponents.url {
-                    return (extractedRedirectUri.absoluteString, true)
-                }
+            if let extractedRedirectUri = Self.extractIntermediateRedirectUri(url) {
+                return (extractedRedirectUri, true)
             }
 
             let fallbackRedirectUri = magicLinkRedirectUri
@@ -1056,15 +1050,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                 
                 if hasCode {
                     // This is magic link flow - extract redirect_uri from this intermediate URL (without query parameters)
-                    if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-                        var redirectUriComponents = URLComponents()
-                        redirectUriComponents.scheme = urlComponents.scheme
-                        redirectUriComponents.host = urlComponents.host
-                        redirectUriComponents.path = urlComponents.path
-                        if let redirectUri = redirectUriComponents.url {
-                            self.magicLinkRedirectUri = redirectUri.absoluteString
-                            logger.trace("Detected magic link redirect_uri: \(self.magicLinkRedirectUri!)")
-                        }
+                    if let redirectUri = Self.extractIntermediateRedirectUri(url) {
+                        self.magicLinkRedirectUri = redirectUri
+                        logger.trace("Detected magic link redirect_uri: \(self.magicLinkRedirectUri!)")
                     }
                 } else {
                     // This is unlock account flow - clear any existing magicLinkRedirectUri and reset state
@@ -1771,5 +1759,17 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     
     override open var safeAreaInsets: UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+}
+
+extension CustomWebView {
+    internal static func extractIntermediateRedirectUri(_ url: URL) -> String? {
+        guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        urlComponents.query = nil
+        urlComponents.fragment = nil
+        return urlComponents.url?.absoluteString
     }
 }

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -264,8 +264,22 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             let queryItems = getQueryItems(url.absoluteString)
             if let redirectUri = queryItems?["redirectUri"]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !redirectUri.isEmpty {
-                return (redirectUri, false)
+                if let matchedRedirectUri = matchedGeneratedRedirectUri(
+                    redirectUri,
+                    baseUrl: baseUrl,
+                    bundleIdentifier: bundleIdentifier
+                ) {
+                    return (matchedRedirectUri, false)
+                }
+
+                let logger = getLogger("CustomWebView")
+                logger.warning("Ignoring unexpected redirectUri from social success payload: \(redirectUri)")
             }
+
+            return (
+                generateRedirectUri(baseUrl: baseUrl, bundleIdentifier: bundleIdentifier),
+                false
+            )
         }
 
         if let actualRedirectUri = matchedGeneratedRedirectUri(

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -80,31 +80,26 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         cancelSocialSuccessWatchdog()
 
         let workItem = DispatchWorkItem { [weak self, weak webView] in
-            guard let self = self, let webView = webView else { return }
-            let currentUrl = webView.url ?? url
-            let queryItems = getQueryItems(currentUrl.absoluteString)
+            guard let self = self else { return }
+            let currentUrl = webView?.url ?? url
 
             guard currentUrl.path.contains("/oauth/account/social/success") else {
                 return
             }
 
-            if queryItems?["code"] != nil {
-                self.logger.warning(
-                    "Social login success page stalled, handling callback directly for \(currentUrl.absoluteString)"
-                )
-                DispatchQueue.main.async { [weak self, weak webView] in
-                    guard let self = self, let webView = webView else { return }
-                    webView.stopLoading()
-                    _ = self.handleHostedLoginCallback(webView, currentUrl)
-                }
-                return
-            }
-
+            // The social success page is still showing after the timeout. This means
+            // the server-side code exchange (e.g. Google → Frontegg) either failed or
+            // is still in progress. The page may contain an error message that the
+            // loading overlay is hiding. Hide the loader so the user can see the
+            // server's response. Do NOT extract the provider code and send it to
+            // /oauth/token — that endpoint expects a Frontegg authorization code,
+            // not a provider code.
             self.logger.warning(
-                "Social login success page stalled without code, reloading fresh login page"
+                "Social login success page stalled, hiding loader to reveal server response for \(currentUrl.absoluteString)"
             )
             DispatchQueue.main.async { [weak self] in
-                self?.reloadFreshLoginPage()
+                self?.fronteggAuth.setWebLoading(false)
+                self?.fronteggAuth.setLoginBoxLoading(false)
             }
         }
 

--- a/Sources/FronteggSwift/utils/FronteggRuntime.swift
+++ b/Sources/FronteggSwift/utils/FronteggRuntime.swift
@@ -3,9 +3,14 @@ import Foundation
 enum FronteggRuntime {
     static let testingEnvironmentKey = "frontegg-testing"
     static let testingWebAuthenticationTransportEnvironmentKey = "FRONTEGG_TEST_WEB_AUTH_TRANSPORT"
+    static let xctestConfigurationEnvironmentKey = "XCTestConfigurationFilePath"
 
     static var isTesting: Bool {
         ProcessInfo.processInfo.environment[testingEnvironmentKey] == "true"
+    }
+
+    static var isRunningUnderXCTest: Bool {
+        ProcessInfo.processInfo.environment[xctestConfigurationEnvironmentKey] != nil
     }
 
     static func testingLog(_ message: @autoclosure () -> String) {

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -184,6 +184,7 @@ public enum NetworkStatusMonitor {
     private static let _initialCheckLock = NSLock()
     private static var _isMonitoringActive = false
     private static let _monitoringLock = NSLock()
+    private static var _monitorSessionGeneration: UInt64 = 0
     private static var _probeGeneration: UInt64 = 0
     private static var _emitInitialState = true
 
@@ -270,12 +271,17 @@ public enum NetworkStatusMonitor {
         onChange: ((Bool) -> Void)? = nil
     ) {
         // Prevent multiple simultaneous starts - check and set flag atomically
+        var sessionGeneration: UInt64 = 0
         _monitoringLock.lock()
         if _isMonitoringActive {
             _monitoringLock.unlock()
             return // Already monitoring, skip duplicate start
         }
         _isMonitoringActive = true
+        _monitorSessionGeneration &+= 1
+        sessionGeneration = _monitorSessionGeneration
+        _probeGeneration &+= 1
+        _emitInitialState = emitInitialState
         _monitoringLock.unlock()
         
         // Stop any existing monitoring resources (defensive cleanup)
@@ -297,14 +303,14 @@ public enum NetworkStatusMonitor {
             _cachedReachable = false
             _hasCachedReachable = false
         }
-        _monitoringLock.withLock {
-            _probeGeneration &+= 1
-            _emitInitialState = emitInitialState
-        }
-        
         // Retain the path monitor
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { path in
+            let isCurrentSession = _monitoringLock.withLock {
+                _isMonitoringActive && sessionGeneration == _monitorSessionGeneration
+            }
+            guard isCurrentSession else { return }
+
             // Use lock to safely check and set the initial check flag atomically
             // This prevents duplicate /test calls when NWPathMonitor fires multiple times rapidly
             var shouldForceEmit = false
@@ -320,7 +326,8 @@ public enum NetworkStatusMonitor {
             refreshReachability(
                 for: path,
                 forceEmit: shouldForceEmit,
-                suppressEmit: shouldSuppressInitialEmission
+                suppressEmit: shouldSuppressInitialEmission,
+                expectedMonitoringGeneration: sessionGeneration
             )
         }
         pathMonitor = monitor
@@ -333,8 +340,16 @@ public enum NetworkStatusMonitor {
             let t = DispatchSource.makeTimerSource(queue: backgroundQueue)
             t.schedule(deadline: .now() + interval, repeating: interval)
             t.setEventHandler {
+                let isCurrentSession = _monitoringLock.withLock {
+                    _isMonitoringActive && sessionGeneration == _monitorSessionGeneration
+                }
+                guard isCurrentSession else { return }
+
                 Task {
-                    _ = await probeReachability(forceEmit: false)
+                    _ = await probeReachability(
+                        forceEmit: false,
+                        expectedMonitoringGeneration: sessionGeneration
+                    )
                 }
             }
             t.resume()
@@ -347,6 +362,7 @@ public enum NetworkStatusMonitor {
     public static func stopBackgroundMonitoring() {
         _monitoringLock.lock()
         _isMonitoringActive = false
+        _monitorSessionGeneration &+= 1
         _probeGeneration &+= 1
         _emitInitialState = true
         _monitoringLock.unlock()
@@ -412,8 +428,16 @@ public enum NetworkStatusMonitor {
     private static func refreshReachability(
         for path: NWPath,
         forceEmit: Bool,
-        suppressEmit: Bool = false
+        suppressEmit: Bool = false,
+        expectedMonitoringGeneration: UInt64? = nil
     ) {
+        if let expectedMonitoringGeneration {
+            let isCurrentSession = _monitoringLock.withLock {
+                _isMonitoringActive && expectedMonitoringGeneration == _monitorSessionGeneration
+            }
+            guard isCurrentSession else { return }
+        }
+
         if path.status != .satisfied {
             _monitoringLock.withLock {
                 _probeGeneration &+= 1
@@ -428,17 +452,28 @@ public enum NetworkStatusMonitor {
         }
 
         Task {
-            _ = await probeReachability(forceEmit: forceEmit, suppressEmit: suppressEmit)
+            _ = await probeReachability(
+                forceEmit: forceEmit,
+                suppressEmit: suppressEmit,
+                expectedMonitoringGeneration: expectedMonitoringGeneration
+            )
         }
     }
 
     @discardableResult
     private static func probeReachability(
         forceEmit: Bool,
-        suppressEmit: Bool = false
+        suppressEmit: Bool = false,
+        expectedMonitoringGeneration: UInt64? = nil
     ) async -> Bool {
 #if DEBUG
         if let override = testReachabilityOverride {
+            if let expectedMonitoringGeneration {
+                let isCurrentSession = _monitoringLock.withLock {
+                    _isMonitoringActive && expectedMonitoringGeneration == _monitorSessionGeneration
+                }
+                guard isCurrentSession else { return override }
+            }
             updateCached(override, forceEmit: forceEmit, suppressEmit: suppressEmit)
             return override
         }
@@ -449,16 +484,26 @@ public enum NetworkStatusMonitor {
                 return _probeGeneration
             }
             let ok = await checkServerConnectivity(baseURLString: base)
-            let isCurrentProbe = _monitoringLock.withLock {
-                generation == _probeGeneration
+            let (isCurrentProbe, isCurrentSession) = _monitoringLock.withLock {
+                (
+                    generation == _probeGeneration,
+                    expectedMonitoringGeneration == nil
+                        || (_isMonitoringActive && expectedMonitoringGeneration == _monitorSessionGeneration)
+                )
             }
-            if isCurrentProbe {
+            if isCurrentProbe && isCurrentSession {
                 updateCached(ok, forceEmit: forceEmit, suppressEmit: suppressEmit)
             }
             return ok
         }
 
         let route = await routeIsAvailableOnce()
+        if let expectedMonitoringGeneration {
+            let isCurrentSession = _monitoringLock.withLock {
+                _isMonitoringActive && expectedMonitoringGeneration == _monitorSessionGeneration
+            }
+            guard isCurrentSession else { return route }
+        }
         updateCached(route, forceEmit: forceEmit, suppressEmit: suppressEmit)
         return route
     }
@@ -521,6 +566,7 @@ extension NetworkStatusMonitor {
         }
         _monitoringLock.withLock {
             _isMonitoringActive = false
+            _monitorSessionGeneration = 0
             _probeGeneration = 0
             _emitInitialState = true
         }
@@ -549,6 +595,22 @@ extension NetworkStatusMonitor {
 
     static func _testSetReachabilityOverride(_ available: Bool?) {
         testReachabilityOverride = available
+    }
+
+    static func _testCurrentMonitoringGeneration() -> UInt64 {
+        _monitoringLock.withLock { _monitorSessionGeneration }
+    }
+
+    static func _testEmitCachedForMonitoringGeneration(
+        _ value: Bool,
+        expectedGeneration: UInt64,
+        forceEmit: Bool = false
+    ) {
+        let isCurrentSession = _monitoringLock.withLock {
+            _isMonitoringActive && expectedGeneration == _monitorSessionGeneration
+        }
+        guard isCurrentSession else { return }
+        updateCached(value, forceEmit: forceEmit)
     }
 
     static func _testEmitCached(_ value: Bool, forceEmit: Bool = false) {

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -200,6 +200,12 @@ public enum NetworkStatusMonitor {
 
     private static let stateLock = NSLock()
 
+#if DEBUG
+    private static func currentTestReachabilityOverride() -> Bool? {
+        stateLock.withLock { testReachabilityOverride }
+    }
+#endif
+
     // MARK: - Public API
 
     /// Register an additional on-change handler at runtime.
@@ -408,7 +414,7 @@ public enum NetworkStatusMonitor {
         treatRedirectsAsOffline: Bool = true
     ) async -> Bool {
 #if DEBUG
-        if let override = testReachabilityOverride {
+        if let override = currentTestReachabilityOverride() {
             return override
         }
 #endif
@@ -437,6 +443,13 @@ public enum NetworkStatusMonitor {
             }
             guard isCurrentSession else { return }
         }
+
+#if DEBUG
+        if let override = currentTestReachabilityOverride() {
+            updateCached(override, forceEmit: forceEmit, suppressEmit: suppressEmit)
+            return
+        }
+#endif
 
         if path.status != .satisfied {
             _monitoringLock.withLock {
@@ -467,7 +480,7 @@ public enum NetworkStatusMonitor {
         expectedMonitoringGeneration: UInt64? = nil
     ) async -> Bool {
 #if DEBUG
-        if let override = testReachabilityOverride {
+        if let override = currentTestReachabilityOverride() {
             if let expectedMonitoringGeneration {
                 let isCurrentSession = _monitoringLock.withLock {
                     _isMonitoringActive && expectedMonitoringGeneration == _monitorSessionGeneration
@@ -556,9 +569,9 @@ extension NetworkStatusMonitor {
         pathMonitor?.cancel()
         pathMonitor = nil
         configuredBaseURLString = nil
-        testReachabilityOverride = nil
 
         stateLock.withLock {
+            testReachabilityOverride = nil
             _onChangeHandlers.removeAll()
             _indexMap.removeAll()
             _cachedReachable = false
@@ -594,7 +607,9 @@ extension NetworkStatusMonitor {
     }
 
     static func _testSetReachabilityOverride(_ available: Bool?) {
-        testReachabilityOverride = available
+        stateLock.withLock {
+            testReachabilityOverride = available
+        }
     }
 
     static func _testCurrentMonitoringGeneration() -> UInt64 {

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -167,6 +167,9 @@ private func checkServerConnectivity(
 public enum NetworkStatusMonitor {
     // Configuration
     private static var configuredBaseURLString: String?
+#if DEBUG
+    private static var testReachabilityOverride: Bool?
+#endif
 
     // Strong refs (retain these!)
     private static var pathMonitor: NWPathMonitor?
@@ -388,6 +391,11 @@ public enum NetworkStatusMonitor {
         timeout: TimeInterval = 3,
         treatRedirectsAsOffline: Bool = true
     ) async -> Bool {
+#if DEBUG
+        if let override = testReachabilityOverride {
+            return override
+        }
+#endif
         if let base = configuredBaseURLString {
             return await checkServerConnectivity(
                 baseURLString: base,
@@ -429,6 +437,12 @@ public enum NetworkStatusMonitor {
         forceEmit: Bool,
         suppressEmit: Bool = false
     ) async -> Bool {
+#if DEBUG
+        if let override = testReachabilityOverride {
+            updateCached(override, forceEmit: forceEmit, suppressEmit: suppressEmit)
+            return override
+        }
+#endif
         if let base = configuredBaseURLString {
             let generation = _monitoringLock.withLock {
                 _probeGeneration &+= 1
@@ -497,6 +511,7 @@ extension NetworkStatusMonitor {
         pathMonitor?.cancel()
         pathMonitor = nil
         configuredBaseURLString = nil
+        testReachabilityOverride = nil
 
         stateLock.withLock {
             _onChangeHandlers.removeAll()
@@ -530,6 +545,10 @@ extension NetworkStatusMonitor {
         _initialCheckLock.withLock {
             _hasInitialCheckFired = hasInitialCheckFired
         }
+    }
+
+    static func _testSetReachabilityOverride(_ available: Bool?) {
+        testReachabilityOverride = available
     }
 
     static func _testEmitCached(_ value: Bool, forceEmit: Bool = false) {

--- a/Sources/FronteggSwift/utils/UrlHelper.swift
+++ b/Sources/FronteggSwift/utils/UrlHelper.swift
@@ -56,32 +56,174 @@ public func getURLComonents(_ urlString: String?) -> NSURLComponents? {
     return components
 }
 
+func normalizedBasePath(_ path: String) -> String {
+    guard !path.isEmpty, path != "/" else {
+        return ""
+    }
+
+    var normalized = path
+    if !normalized.hasPrefix("/") {
+        normalized = "/\(normalized)"
+    }
+
+    while normalized.count > 1 && normalized.hasSuffix("/") {
+        normalized.removeLast()
+    }
+
+    return normalized
+}
+
+func currentAppBundleIdentifier() -> String {
+    Bundle.main.bundleIdentifier?.lowercased() ?? ""
+}
+
+func routedAppPath(
+    _ url: URL,
+    baseUrl: String = FronteggApp.shared.baseUrl
+) -> String {
+    let actualPath = normalizedBasePath(url.path)
+
+    guard
+        let baseComponents = URLComponents(string: baseUrl),
+        let baseHost = baseComponents.host?.lowercased(),
+        let urlHost = url.host?.lowercased(),
+        baseHost == urlHost
+    else {
+        return actualPath.isEmpty ? "/" : actualPath
+    }
+
+    let basePath = normalizedBasePath(baseComponents.path)
+    guard !basePath.isEmpty else {
+        return actualPath.isEmpty ? "/" : actualPath
+    }
+
+    if actualPath == basePath {
+        return "/"
+    }
+
+    if actualPath.hasPrefix(basePath + "/") {
+        let strippedPath = String(actualPath.dropFirst(basePath.count))
+        return strippedPath.isEmpty ? "/" : strippedPath
+    }
+
+    return actualPath.isEmpty ? "/" : actualPath
+}
+
+func supportedGeneratedRedirectUris(
+    baseUrl: String = FronteggApp.shared.baseUrl,
+    bundleIdentifier: String = currentAppBundleIdentifier()
+) -> [String] {
+    guard
+        let urlComponents = URLComponents(string: baseUrl),
+        let host = urlComponents.host
+    else {
+        return []
+    }
+
+    let scheme = bundleIdentifier.lowercased()
+    let basePath = normalizedBasePath(urlComponents.path)
+    let callbackPath = "/ios/oauth/callback"
+    let candidatePaths = basePath.isEmpty
+        ? [callbackPath]
+        : ["\(basePath)\(callbackPath)", callbackPath]
+
+    var seen = Set<String>()
+    var uris: [String] = []
+
+    for path in candidatePaths {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        components.path = path
+
+        guard let uri = components.url?.absoluteString else {
+            continue
+        }
+
+        if seen.insert(uri).inserted {
+            uris.append(uri)
+        }
+    }
+
+    return uris
+}
+
+func matchedGeneratedRedirectUri(
+    _ url: URL,
+    baseUrl: String = FronteggApp.shared.baseUrl,
+    bundleIdentifier: String = currentAppBundleIdentifier()
+) -> String? {
+    guard
+        let actual = URLComponents(url: url, resolvingAgainstBaseURL: false),
+        let actualScheme = actual.scheme?.lowercased(),
+        let actualHost = actual.host?.lowercased()
+    else {
+        return nil
+    }
+
+    let actualPath = normalizedBasePath(actual.path)
+
+    for candidateUri in supportedGeneratedRedirectUris(
+        baseUrl: baseUrl,
+        bundleIdentifier: bundleIdentifier
+    ) {
+        guard let expected = URLComponents(string: candidateUri) else {
+            continue
+        }
+
+        if actualScheme == expected.scheme?.lowercased(),
+           actualHost == expected.host?.lowercased(),
+           actualPath == normalizedBasePath(expected.path) {
+            var matched = URLComponents()
+            matched.scheme = actualScheme
+            matched.host = actual.host
+            matched.path = actualPath
+            return matched.url?.absoluteString
+        }
+    }
+
+    return nil
+}
+
+func generateRedirectUri(
+    baseUrl: String,
+    bundleIdentifier: String
+) -> String {
+    guard let redirectUri = supportedGeneratedRedirectUris(
+        baseUrl: baseUrl,
+        bundleIdentifier: bundleIdentifier
+    ).first else {
+        print("Failed to generate redirect uri, baseUrl: \(baseUrl)")
+        exit(1)
+    }
+
+    return redirectUri
+}
+
 public func generateRedirectUri() -> String {
 
     let baseUrl = FronteggApp.shared.baseUrl
     let bundleIdentifier = FronteggApp.shared.bundleIdentifier
-    
-    // return "com.frontegg.demo://auth.davidantoon.me/ios/oauth/callback
-    
-    guard let urlComponents = URLComponents(string: baseUrl) else {
-        
-        print("Failed to generate redirect uri, baseUrl: \(baseUrl)")
-        exit(1)
-    }
-    
-    // Normalize path - if path is empty or just "/", don't include it
-    var path = urlComponents.path
-    if path.isEmpty || path == "/" {
-        path = ""
-    }
-    
-    let redirectUri = "\(bundleIdentifier.lowercased())://\(urlComponents.host!)\(path)/ios/oauth/callback"
+
+    let redirectUri = generateRedirectUri(
+        baseUrl: baseUrl,
+        bundleIdentifier: bundleIdentifier
+    )
+    let urlComponents = URLComponents(string: baseUrl)
+    let path = normalizedBasePath(urlComponents?.path ?? "")
+    let supportedRedirectUris = supportedGeneratedRedirectUris(
+        baseUrl: baseUrl,
+        bundleIdentifier: bundleIdentifier
+    )
     let logger = getLogger("UrlHelper")
     logger.info("🔵 [Social Login Debug] Generated redirect URI: \(redirectUri)")
     logger.info("🔵 [Social Login Debug]   - Base URL: \(baseUrl)")
     logger.info("🔵 [Social Login Debug]   - Bundle ID: \(bundleIdentifier)")
-    logger.info("🔵 [Social Login Debug]   - URL host: \(urlComponents.host ?? "nil")")
+    logger.info("🔵 [Social Login Debug]   - URL host: \(urlComponents?.host ?? "nil")")
     logger.info("🔵 [Social Login Debug]   - URL path: \(path)")
+    if supportedRedirectUris.count > 1 {
+        logger.info("🔵 [Social Login Debug]   - Supported callback aliases: \(supportedRedirectUris.joined(separator: ", "))")
+    }
     
     return redirectUri
 }
@@ -117,24 +259,25 @@ func isSocialLoginPath(_ string: String) -> Bool {
 func getOverrideUrlType (url: URL) -> OverrideUrlType {
     
     let urlStr = url.absoluteString
+    let routedPath = routedAppPath(url)
     
     if urlStr.starts(with: FronteggApp.shared.baseUrl) {
         
-        if(isSocialLoginPath(url.path)){
+        if(isSocialLoginPath(routedPath)){
             return .SocialOauthPreLogin
         }
         
-        if((URLConstants.successLoginRoutes.first { url.path.hasPrefix($0)}) != nil) {
+        if((URLConstants.successLoginRoutes.first { routedPath.hasPrefix($0)}) != nil) {
             return .loginRoutes
         }
-        if((URLConstants.loginRoutes.first { url.path.hasPrefix($0)}) != nil) {
+        if((URLConstants.loginRoutes.first { routedPath.hasPrefix($0)}) != nil) {
             return .loginRoutes
         }
         
         return .internalRoutes
     }
     
-    if(url.absoluteString.starts(with: generateRedirectUri())){
+    if matchedGeneratedRedirectUri(url) != nil {
         return .HostedLoginCallback
     }
     return .Unknown

--- a/Sources/FronteggSwift/utils/UrlHelper.swift
+++ b/Sources/FronteggSwift/utils/UrlHelper.swift
@@ -213,11 +213,30 @@ func generateRedirectUri(
         baseUrl: baseUrl,
         bundleIdentifier: bundleIdentifier
     ).first else {
-        print("Failed to generate redirect uri, baseUrl: \(baseUrl)")
-        exit(1)
+        let logger = getLogger("UrlHelper")
+        let message = "Failed to generate redirect uri, baseUrl: \(baseUrl), bundleIdentifier: \(bundleIdentifier)"
+        logger.error(message)
+#if DEBUG
+        if !FronteggRuntime.isTesting && !FronteggRuntime.isRunningUnderXCTest {
+            assertionFailure(message)
+        }
+#endif
+        return invalidGeneratedRedirectUri(bundleIdentifier: bundleIdentifier)
     }
 
     return redirectUri
+}
+
+func invalidGeneratedRedirectUri(bundleIdentifier: String) -> String {
+    let fallbackScheme = bundleIdentifier.isEmpty
+        ? "frontegg-invalid"
+        : bundleIdentifier.lowercased()
+
+    var components = URLComponents()
+    components.scheme = fallbackScheme
+    components.host = "invalid"
+    components.path = "/ios/oauth/callback"
+    return components.url?.absoluteString ?? "frontegg-invalid://invalid/ios/oauth/callback"
 }
 
 public func generateRedirectUri() -> String {

--- a/Sources/FronteggSwift/utils/UrlHelper.swift
+++ b/Sources/FronteggSwift/utils/UrlHelper.swift
@@ -74,7 +74,11 @@ func normalizedBasePath(_ path: String) -> String {
 }
 
 func currentAppBundleIdentifier() -> String {
-    Bundle.main.bundleIdentifier?.lowercased() ?? ""
+    if !FronteggApp.shared.bundleIdentifier.isEmpty {
+        return FronteggApp.shared.bundleIdentifier.lowercased()
+    }
+
+    return Bundle.main.bundleIdentifier?.lowercased() ?? ""
 }
 
 func routedAppPath(
@@ -185,6 +189,22 @@ func matchedGeneratedRedirectUri(
     return nil
 }
 
+func matchedGeneratedRedirectUri(
+    _ redirectUri: String,
+    baseUrl: String = FronteggApp.shared.baseUrl,
+    bundleIdentifier: String = currentAppBundleIdentifier()
+) -> String? {
+    guard let url = URL(string: redirectUri) else {
+        return nil
+    }
+
+    return matchedGeneratedRedirectUri(
+        url,
+        baseUrl: baseUrl,
+        bundleIdentifier: bundleIdentifier
+    )
+}
+
 func generateRedirectUri(
     baseUrl: String,
     bundleIdentifier: String
@@ -203,7 +223,7 @@ func generateRedirectUri(
 public func generateRedirectUri() -> String {
 
     let baseUrl = FronteggApp.shared.baseUrl
-    let bundleIdentifier = FronteggApp.shared.bundleIdentifier
+    let bundleIdentifier = currentAppBundleIdentifier()
 
     let redirectUri = generateRedirectUri(
         baseUrl: baseUrl,

--- a/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
+++ b/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
@@ -86,18 +86,33 @@ internal struct ProviderDetails {
     }
 }
 
-private actor PendingCustomProviderCodeVerifierStore {
+private final class PendingSocialProviderCodeVerifierStore {
+    private let lock = NSLock()
     private var verifiersByState: [String: String] = [:]
 
-    func store(_ verifier: String, for oauthState: String) {
-        verifiersByState[oauthState] = verifier
+    func store(_ verifier: String, for oauthStates: [String]) {
+        lock.withLock {
+            for oauthState in oauthStates where !oauthState.isEmpty {
+                verifiersByState[oauthState] = verifier
+            }
+        }
     }
 
-    func take(for oauthState: String) -> String? {
-        defer {
-            verifiersByState.removeValue(forKey: oauthState)
+    func verifier(for oauthStates: [String]) -> String? {
+        lock.withLock {
+            for oauthState in oauthStates {
+                if let verifier = verifiersByState[oauthState] {
+                    return verifier
+                }
+            }
+            return nil
         }
-        return verifiersByState[oauthState]
+    }
+
+    func clearAll() {
+        lock.withLock {
+            verifiersByState.removeAll()
+        }
     }
 }
 
@@ -109,7 +124,7 @@ public final class SocialLoginUrlGenerator {
     private var socialLoginConfig: SocialLoginConfig?
     private var customSocialLoginConfigs: [CustomSocialLoginProviderConfig]?
     private let logger = getLogger("SocialLoginUrlGenerator")
-    private let pendingCustomProviderCodeVerifiers = PendingCustomProviderCodeVerifierStore()
+    private let pendingSocialProviderCodeVerifiers = PendingSocialProviderCodeVerifierStore()
     
     
     /// Generates an authorization URL for a standard social login provider.
@@ -289,6 +304,7 @@ private extension SocialLoginUrlGenerator {
             // and the verifier used on the backend, we MUST always read the verifier
             // from the webview (localStorage) here.
             let verifier: String = try await Self.getCodeVerifierFromWebview()
+            storePendingSocialCodeVerifier(verifier, for: state)
             
             let codeChallenge = verifier.s256CodeChallenge()
             logger.info("🔵 [PKCE Debug] Generated code_challenge for \(provider.rawValue) (first 20 chars): \(String(codeChallenge.prefix(20)))")
@@ -363,7 +379,7 @@ private extension SocialLoginUrlGenerator {
                 do {
                     let verifier: String = try await Self.getCodeVerifierFromWebview()
                     logger.info("🔵 [PKCE Debug] Captured code verifier for custom provider \(provider.displayName) (first 10 chars): \(String(verifier.prefix(10)))")
-                    await storePendingCustomProviderCodeVerifier(verifier, for: state)
+                    storePendingSocialCodeVerifier(verifier, for: state)
                 } catch {
                     logger.warning("Failed to capture code verifier for custom provider \(provider.displayName): \(error)")
                 }
@@ -388,6 +404,13 @@ public extension SocialLoginUrlGenerator {
         let platform: String
         let oauthState: String?
     }
+
+    struct CanonicalOAuthState: Codable {
+        let provider: String
+        let appId: String
+        let action: String
+        let oauthState: String?
+    }
     
     static func createState(provider: SocialLoginProvider, appId: String?, action: SocialLoginAction, oauthState: String? = nil) throws -> String {
         return try createState(provider: provider.rawValue, appId: appId, action: action, oauthState: oauthState)
@@ -404,6 +427,122 @@ public extension SocialLoginUrlGenerator {
         )
         let data = try JSONEncoder().encode(stateObject)
         return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    static func canonicalizeSocialState(_ state: String) -> String {
+        guard let components = decodeSocialStateComponents(from: state) else {
+            return state
+        }
+
+        return encodeCanonicalSocialState(
+            provider: components.provider,
+            appId: components.appId,
+            action: components.action,
+            oauthState: components.oauthState
+        ) ?? state
+    }
+
+    static func socialStateLookupKeys(for state: String?) -> [String] {
+        guard let state, !state.isEmpty else {
+            return []
+        }
+
+        var lookupKeys = [state]
+
+        if let components = decodeSocialStateComponents(from: state) {
+            if let canonicalState = encodeCanonicalSocialState(
+                provider: components.provider,
+                appId: components.appId,
+                action: components.action,
+                oauthState: components.oauthState
+            ), canonicalState != state {
+                lookupKeys.append(canonicalState)
+            }
+
+            lookupKeys.append(
+                normalizedSocialStateLookupKey(
+                    provider: components.provider,
+                    appId: components.appId,
+                    action: components.action,
+                    oauthState: components.oauthState
+                )
+            )
+        }
+
+        return uniqueLookupKeys(lookupKeys)
+    }
+
+    private static func encodeCanonicalSocialState(
+        provider: String,
+        appId: String,
+        action: String,
+        oauthState: String?
+    ) -> String? {
+        let canonicalState = CanonicalOAuthState(
+            provider: provider,
+            appId: appId,
+            action: action,
+            oauthState: oauthState
+        )
+        guard let data = try? JSONEncoder().encode(canonicalState) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func decodeSocialStateComponents(
+        from state: String
+    ) -> (provider: String, appId: String, action: String, oauthState: String?)? {
+        guard let data = state.data(using: .utf8) else {
+            return nil
+        }
+
+        if let oauthState = try? JSONDecoder().decode(OAuthState.self, from: data) {
+            return (
+                provider: oauthState.provider,
+                appId: oauthState.appId,
+                action: oauthState.action,
+                oauthState: oauthState.oauthState
+            )
+        }
+
+        if let canonicalState = try? JSONDecoder().decode(CanonicalOAuthState.self, from: data) {
+            return (
+                provider: canonicalState.provider,
+                appId: canonicalState.appId,
+                action: canonicalState.action,
+                oauthState: canonicalState.oauthState
+            )
+        }
+
+        return nil
+    }
+
+    private static func normalizedSocialStateLookupKey(
+        provider: String,
+        appId: String,
+        action: String,
+        oauthState: String?
+    ) -> String {
+        [
+            "provider=\(provider)",
+            "appId=\(appId)",
+            "action=\(action)",
+            "oauthState=\(oauthState ?? "")"
+        ].joined(separator: "&")
+    }
+
+    private static func uniqueLookupKeys(_ keys: [String]) -> [String] {
+        var seen = Set<String>()
+        var deduped: [String] = []
+
+        for key in keys where !key.isEmpty {
+            if seen.insert(key).inserted {
+                deduped.append(key)
+            }
+        }
+
+        return deduped
     }
 
     /// Reads the OAuth session state keys from webview localStorage and returns a base64-encoded JSON string.
@@ -460,7 +599,7 @@ public extension SocialLoginUrlGenerator {
         guard let oauthState, !oauthState.isEmpty else {
             return
         }
-        guard let verifier = await consumePendingCustomProviderCodeVerifier(for: oauthState) else {
+        guard let verifier = pendingSocialCodeVerifier(for: oauthState) else {
             return
         }
 
@@ -493,12 +632,21 @@ public extension SocialLoginUrlGenerator {
         return baseRedirectUri
     }
 
-    func storePendingCustomProviderCodeVerifier(_ verifier: String, for oauthState: String) async {
-        await pendingCustomProviderCodeVerifiers.store(verifier, for: oauthState)
+    func storePendingSocialCodeVerifier(_ verifier: String, for oauthState: String) {
+        pendingSocialProviderCodeVerifiers.store(
+            verifier,
+            for: Self.socialStateLookupKeys(for: oauthState)
+        )
     }
 
-    func consumePendingCustomProviderCodeVerifier(for oauthState: String) async -> String? {
-        await pendingCustomProviderCodeVerifiers.take(for: oauthState)
+    func pendingSocialCodeVerifier(for oauthState: String?) -> String? {
+        pendingSocialProviderCodeVerifiers.verifier(
+            for: Self.socialStateLookupKeys(for: oauthState)
+        )
+    }
+
+    func clearPendingSocialCodeVerifiers() {
+        pendingSocialProviderCodeVerifiers.clearAll()
     }
 
     func codeVerifierInjectionScript(verifier: String) throws -> String {

--- a/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
+++ b/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
@@ -421,7 +421,7 @@ public extension SocialLoginUrlGenerator {
             provider: provider,
             appId: appId ?? "",
             action: action.rawValue,
-            bundleId: FronteggApp.shared.bundleIdentifier,
+            bundleId: currentAppBundleIdentifier(),
             platform: "ios",
             oauthState: oauthState
         )
@@ -626,7 +626,7 @@ public extension SocialLoginUrlGenerator {
     
     func defaultRedirectUri() -> String {
         let base = FronteggAuth.shared.baseUrl
-        let bundleId = FronteggApp.shared.bundleIdentifier
+        let bundleId = currentAppBundleIdentifier()
         let baseRedirectUri = "\(base)/oauth/account/redirect/ios/\(bundleId)"
 
         return baseRedirectUri

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -49,6 +49,33 @@ final class CustomWebViewTests: XCTestCase {
         XCTAssertNil(resolution.providerError)
     }
 
+    func test_resolveHostedCallbackCodeVerifier_socialFallsBackToPendingSocialStateStore() async throws {
+        let rawState = try makeRawSocialState(
+            provider: "google",
+            appId: "app-1",
+            action: "login"
+        )
+        let canonicalState = SocialLoginUrlGenerator.canonicalizeSocialState(rawState)
+
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
+            "pending-social-verifier",
+            for: rawState
+        )
+
+        let resolution = await CustomWebView.resolveHostedCallbackCodeVerifier(
+            isMagicLink: false,
+            isSocialLogin: true,
+            oauthState: canonicalState,
+            socialVerifierProvider: {
+                throw URLError(.timedOut)
+            }
+        )
+
+        XCTAssertEqual(resolution.codeVerifier, "pending-social-verifier")
+        XCTAssertEqual(resolution.source, "pending_social_state_store")
+        XCTAssertNotNil(resolution.providerError)
+    }
+
     func test_resolveHostedCallbackCodeVerifier_socialFallsBackToLastGeneratedVerifier() async {
         CredentialManager.registerPendingOAuth(state: "expected-state", codeVerifier: "shared-verifier")
 
@@ -231,5 +258,28 @@ final class CustomWebViewTests: XCTestCase {
     private func clearOAuthState() {
         UserDefaults.standard.removeObject(forKey: KeychainKeys.codeVerifier.rawValue)
         UserDefaults.standard.removeObject(forKey: KeychainKeys.oauthStateVerifiers.rawValue)
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
+    }
+
+    private func makeRawSocialState(
+        provider: String,
+        appId: String,
+        action: String,
+        oauthState: String? = nil
+    ) throws -> String {
+        var payload: [String: String] = [
+            "provider": provider,
+            "appId": appId,
+            "action": action,
+            "bundleId": "com.frontegg.tests",
+            "platform": "ios"
+        ]
+
+        if let oauthState {
+            payload["oauthState"] = oauthState
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
     }
 }

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -123,6 +123,62 @@ final class CustomWebViewTests: XCTestCase {
         XCTAssertEqual(matched.source, "state_match")
     }
 
+    func test_resolveHostedCallbackRedirect_generatedCallbackAliasUsesActualAlias() {
+        let resolution = CustomWebView.resolveHostedCallbackRedirect(
+            url: URL(string: "com.frontegg.demo://auth.example.com/ios/oauth/callback?code=123")!,
+            magicLinkRedirectUri: nil,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo",
+            embeddedMode: true
+        )
+
+        XCTAssertEqual(
+            resolution.redirectUri,
+            "com.frontegg.demo://auth.example.com/ios/oauth/callback"
+        )
+        XCTAssertFalse(resolution.isMagicLink)
+    }
+
+    func test_resolveHostedCallbackRedirect_socialSuccessUsesRedirectUriQuery() {
+        let encodedRedirectUri = "com.frontegg.demo://auth.example.com/ios/oauth/callback"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let url = URL(
+            string: "https://auth.example.com/fe-auth/oauth/account/social/success?code=123&redirectUri=\(encodedRedirectUri)"
+        )!
+
+        let resolution = CustomWebView.resolveHostedCallbackRedirect(
+            url: url,
+            magicLinkRedirectUri: nil,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo",
+            embeddedMode: true
+        )
+
+        XCTAssertEqual(
+            resolution.redirectUri,
+            "com.frontegg.demo://auth.example.com/ios/oauth/callback"
+        )
+        XCTAssertFalse(resolution.isMagicLink)
+    }
+
+    func test_resolveHostedCallbackRedirect_intermediateRedirectUsesExactPath() {
+        let resolution = CustomWebView.resolveHostedCallbackRedirect(
+            url: URL(
+                string: "https://auth.example.com/fe-auth/oauth/account/redirect/ios/com.frontegg.demo/google?code=123"
+            )!,
+            magicLinkRedirectUri: nil,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo",
+            embeddedMode: true
+        )
+
+        XCTAssertEqual(
+            resolution.redirectUri,
+            "https://auth.example.com/fe-auth/oauth/account/redirect/ios/com.frontegg.demo/google"
+        )
+        XCTAssertTrue(resolution.isMagicLink)
+    }
+
     // MARK: - OIDC SSO Flow Tests
     //
     // SSO OIDC (enterprise SSO via Auth0, Okta, etc.) uses Frontegg's standard OAuth PKCE flow.

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -161,6 +161,28 @@ final class CustomWebViewTests: XCTestCase {
         XCTAssertFalse(resolution.isMagicLink)
     }
 
+    func test_resolveHostedCallbackRedirect_socialSuccessFallsBackWhenRedirectUriQueryIsUnexpected() {
+        let encodedRedirectUri = "com.bad.actor://evil.example.com/ios/oauth/callback"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let url = URL(
+            string: "https://auth.example.com/fe-auth/oauth/account/social/success?code=123&redirectUri=\(encodedRedirectUri)"
+        )!
+
+        let resolution = CustomWebView.resolveHostedCallbackRedirect(
+            url: url,
+            magicLinkRedirectUri: nil,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo",
+            embeddedMode: true
+        )
+
+        XCTAssertEqual(
+            resolution.redirectUri,
+            "com.frontegg.demo://auth.example.com/fe-auth/ios/oauth/callback"
+        )
+        XCTAssertFalse(resolution.isMagicLink)
+    }
+
     func test_resolveHostedCallbackRedirect_intermediateRedirectUsesExactPath() {
         let resolution = CustomWebView.resolveHostedCallbackRedirect(
             url: URL(

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -201,6 +201,24 @@ final class CustomWebViewTests: XCTestCase {
         XCTAssertTrue(resolution.isMagicLink)
     }
 
+    func test_resolveHostedCallbackRedirect_intermediateRedirectPreservesNonDefaultPort() {
+        let resolution = CustomWebView.resolveHostedCallbackRedirect(
+            url: URL(
+                string: "https://auth.example.com:8443/fe-auth/oauth/account/redirect/ios/com.frontegg.demo/google?code=123"
+            )!,
+            magicLinkRedirectUri: nil,
+            baseUrl: "https://auth.example.com:8443/fe-auth",
+            bundleIdentifier: "com.frontegg.demo",
+            embeddedMode: true
+        )
+
+        XCTAssertEqual(
+            resolution.redirectUri,
+            "https://auth.example.com:8443/fe-auth/oauth/account/redirect/ios/com.frontegg.demo/google"
+        )
+        XCTAssertTrue(resolution.isMagicLink)
+    }
+
     // MARK: - OIDC SSO Flow Tests
     //
     // SSO OIDC (enterprise SSO via Auth0, Okta, etc.) uses Frontegg's standard OAuth PKCE flow.

--- a/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
@@ -718,6 +718,74 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         }
     }
 
+    func test_handleHostedLoginCallback_socialLoginSuccess_clearsPendingSocialVerifierState() async throws {
+        let rawSocialState = try makeRawSocialState(
+            provider: "google",
+            appId: "app-1",
+            action: "login"
+        )
+        let canonicalSocialState = SocialLoginUrlGenerator.canonicalizeSocialState(rawSocialState)
+        let accessToken = try makeAccessToken()
+        api.exchangeTokenResponse = try makeAuthResponse(
+            accessToken: accessToken,
+            refreshToken: "refresh-token-social-success"
+        )
+        api.meResult = .success(try makeUser())
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
+            "pending-social-verifier",
+            for: rawSocialState
+        )
+
+        let result = await withCheckedContinuation { continuation in
+            auth.handleHostedLoginCallback(
+                "code-social-success",
+                "verifier-social-success",
+                oauthState: canonicalSocialState,
+                redirectUri: "test://callback",
+                flow: .socialLogin,
+                completePendingFlowOnSuccess: false
+            ) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success(let user):
+            XCTAssertEqual(user.email, "test@example.com")
+        case .failure(let error):
+            XCTFail("Expected social login success, got \(error)")
+        }
+
+        XCTAssertNil(SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: rawSocialState))
+        XCTAssertNil(SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: canonicalSocialState))
+    }
+
+    func test_handleSocialLoginOAuthCallback_failure_clearsPendingSocialVerifierState() async throws {
+        let rawSocialState = try SocialLoginUrlGenerator.createState(
+            provider: .google,
+            appId: "app-2",
+            action: .login
+        )
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
+            "pending-social-verifier",
+            for: rawSocialState
+        )
+
+        let result = await executeSocialLoginOAuthCallback(
+            url: nil,
+            error: URLError(.cannotConnectToHost)
+        )
+
+        switch result {
+        case .success:
+            XCTFail("Expected social login callback failure")
+        case .failure:
+            break
+        }
+
+        XCTAssertNil(SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: rawSocialState))
+    }
+
     func test_logout_clearsLoginInProgressWhileHostedLoginCallbackIsInFlight() async {
         api.exchangeTokenError = FronteggError.authError(.failedToAuthenticate)
         api.setExchangeTokenBlocked(true)
@@ -805,6 +873,96 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 900_000_000)
 
         XCTAssertFalse(auth.isOfflineMode)
+    }
+
+    func test_handleHostedLoginCallback_onlineSuccess_cancelsPendingOfflineDebounce() async throws {
+        let accessToken = try makeAccessToken()
+        api.exchangeTokenResponse = try makeAuthResponse(
+            accessToken: accessToken,
+            refreshToken: "refresh-token-online-success"
+        )
+        api.meResult = .success(try makeUser())
+
+        auth.setIsOfflineMode(false)
+        auth.disconnectedFromInternet()
+
+        let result = await executeHostedLoginCallback(
+            code: "code-online-success",
+            codeVerifier: "verifier-online-success"
+        )
+
+        switch result {
+        case .success(let user):
+            XCTAssertEqual(user.email, "test@example.com")
+        case .failure(let error):
+            XCTFail("Expected hosted login callback success, got \(error)")
+        }
+
+        try? await Task.sleep(nanoseconds: 900_000_000)
+
+        XCTAssertTrue(auth.isAuthenticated)
+        XCTAssertFalse(auth.isOfflineMode)
+    }
+
+    func test_logout_whileOffline_keepsUnauthenticatedOfflineModeEnabled() async throws {
+        PlistHelper.testConfigOverride = makeOfflineConfig(serviceKey: serviceKey)
+        NetworkStatusMonitor._testSetReachabilityOverride(false)
+
+        auth.setAccessToken("access-token")
+        auth.setRefreshToken("refresh-token")
+        auth.setUser(try makeUser())
+        auth.setIsAuthenticated(true)
+        auth.setIsOfflineMode(true)
+
+        let result = await withCheckedContinuation { continuation in
+            auth.logout(clearCookie: false) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success(let didLogout):
+            XCTAssertTrue(didLogout)
+        case .failure(let error):
+            XCTFail("Expected logout success, got \(error)")
+        }
+
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertNil(auth.accessToken)
+        XCTAssertNil(auth.refreshToken)
+        XCTAssertTrue(auth.isOfflineMode)
+        XCTAssertTrue(NetworkStatusMonitor._testSnapshot().monitoringActive)
+    }
+
+    func test_logout_online_ignoresPendingOfflineDebounceFromPreviousMonitoring() async throws {
+        PlistHelper.testConfigOverride = makeOfflineConfig(serviceKey: serviceKey)
+        NetworkStatusMonitor._testSetReachabilityOverride(true)
+
+        auth.setAccessToken("access-token")
+        auth.setRefreshToken("refresh-token")
+        auth.setUser(try makeUser())
+        auth.setIsAuthenticated(true)
+        auth.setIsOfflineMode(false)
+        auth.disconnectedFromInternet()
+
+        let result = await withCheckedContinuation { continuation in
+            auth.logout(clearCookie: false) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success(let didLogout):
+            XCTAssertTrue(didLogout)
+        case .failure(let error):
+            XCTFail("Expected logout success, got \(error)")
+        }
+
+        try? await Task.sleep(nanoseconds: 900_000_000)
+
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertFalse(auth.isOfflineMode)
+        XCTAssertTrue(NetworkStatusMonitor._testSnapshot().monitoringActive)
     }
 
     func test_ensureOfflineMonitoringActive_defaultsToSuppressingInitialEmission() {
@@ -1120,6 +1278,29 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
     private func clearOAuthState() {
         UserDefaults.standard.removeObject(forKey: KeychainKeys.codeVerifier.rawValue)
         UserDefaults.standard.removeObject(forKey: KeychainKeys.oauthStateVerifiers.rawValue)
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
+    }
+
+    private func makeRawSocialState(
+        provider: String,
+        appId: String,
+        action: String,
+        oauthState: String? = nil
+    ) throws -> String {
+        var payload: [String: String] = [
+            "provider": provider,
+            "appId": appId,
+            "action": action,
+            "bundleId": "com.frontegg.tests",
+            "platform": "ios"
+        ]
+
+        if let oauthState {
+            payload["oauthState"] = oauthState
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
     }
 
     private func assertOfflineModePersistsBriefly(

--- a/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
@@ -1192,8 +1192,8 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertTrue(initialSnapshot.hasCachedReachable)
 
         auth.recheckConnection()
-        for _ in 0..<20 where auth.isOfflineMode {
-            try? await Task.sleep(nanoseconds: 50_000_000)
+        for _ in 0..<40 where auth.isOfflineMode {
+            try? await Task.sleep(nanoseconds: 100_000_000)
         }
 
         let snapshot = NetworkStatusMonitor._testSnapshot()

--- a/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
@@ -377,6 +377,39 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertEqual(returnedStateObject?["action"], "login")
     }
 
+    func test_handleSocialLoginCallback_runtimeBundleIdentifierOverride_preservesActualCallbackAlias() throws {
+        let app = FronteggApp.shared
+        let previousBundleIdentifier = app.bundleIdentifier
+        let previousBaseUrl = auth.baseUrl
+        app.bundleIdentifier = "com.override.bundle"
+        auth.baseUrl = "https://test.example.com/fe-auth"
+        defer {
+            app.bundleIdentifier = previousBundleIdentifier
+            auth.baseUrl = previousBaseUrl
+        }
+
+        let rawSocialState = try makeRawSocialState(
+            provider: "google",
+            appId: "app-override",
+            action: "login"
+        )
+        let callbackUrl = makeGeneratedRedirectCallbackUrl(
+            bundleIdentifier: "com.override.bundle",
+            path: "/ios/oauth/callback",
+            code: "code-override",
+            state: rawSocialState
+        )
+
+        let finalUrl = auth.handleSocialLoginCallback(callbackUrl)
+        let queryItems = finalUrl.flatMap { getQueryItems($0.absoluteString) }
+
+        XCTAssertEqual(finalUrl?.path, "/fe-auth/oauth/account/social/success")
+        XCTAssertEqual(
+            queryItems?["redirectUri"],
+            "com.override.bundle://test.example.com/ios/oauth/callback"
+        )
+    }
+
     func test_handleSocialLoginOAuthCallback_errorCompletesFailure() async {
         let result = await executeSocialLoginOAuthCallback(
             url: nil,
@@ -447,6 +480,33 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
                 return XCTFail("Expected unknown auth error, got \(authError)")
             }
         }
+    }
+
+    func test_handleSocialLogin_newAttemptClearsPendingSocialVerifierState() async throws {
+        let rawSocialState = try makeRawSocialState(
+            provider: "google",
+            appId: "app-pending-cleanup",
+            action: "login"
+        )
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
+            "stale-social-verifier",
+            for: rawSocialState
+        )
+
+        let result = await withCheckedContinuation { continuation in
+            auth.handleSocialLogin(providerString: "not-a-provider", custom: false) { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success:
+            XCTFail("Expected social login to fail for an unknown provider")
+        case .failure:
+            break
+        }
+
+        XCTAssertNil(SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: rawSocialState))
     }
 
     func test_handleOpenUrl_generatedRedirectError_reportsDecodedErrorDescriptionToDelegate() async {
@@ -525,6 +585,49 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertEqual(
             api.lastExchangeInput?.redirectUrl,
             "\(bundleIdentifier)://test.example.com/ios/oauth/callback"
+        )
+    }
+
+    func test_createOauthCallbackHandler_runtimeBundleIdentifierOverride_usesOverrideForExchange() async throws {
+        let accessToken = try makeAccessToken()
+        api.exchangeTokenResponse = try makeAuthResponse(
+            accessToken: accessToken,
+            refreshToken: "refresh-token-runtime-override"
+        )
+        api.meResult = .success(try makeUser())
+
+        let app = FronteggApp.shared
+        let previousBundleIdentifier = app.bundleIdentifier
+        let previousAuthBaseUrl = auth.baseUrl
+        app.bundleIdentifier = "com.override.bundle"
+        auth.baseUrl = "https://test.example.com/fe-auth"
+        defer {
+            app.bundleIdentifier = previousBundleIdentifier
+            auth.baseUrl = previousAuthBaseUrl
+        }
+
+        CredentialManager.registerPendingOAuth(state: "override-state", codeVerifier: "override-verifier")
+
+        let result = await executeCallback(
+            allowFallback: false,
+            url: makeGeneratedRedirectCallbackUrl(
+                bundleIdentifier: "com.override.bundle",
+                path: "/ios/oauth/callback",
+                code: "code-override",
+                state: "override-state"
+            )
+        )
+
+        switch result {
+        case .success(let user):
+            XCTAssertEqual(user.email, "test@example.com")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+
+        XCTAssertEqual(
+            api.lastExchangeInput?.redirectUrl,
+            "com.override.bundle://test.example.com/ios/oauth/callback"
         )
     }
 
@@ -1045,15 +1148,19 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         auth.setIsOfflineMode(true)
         auth.setIsLoading(false)
         auth.setInitializing(false)
+        auth.ensureOfflineMonitoringActive()
 
         auth.recheckConnection()
         for _ in 0..<20 where auth.isOfflineMode {
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
 
+        let snapshot = NetworkStatusMonitor._testSnapshot()
         XCTAssertFalse(auth.isOfflineMode)
         XCTAssertFalse(auth.isAuthenticated)
         XCTAssertNil(auth.user)
+        XCTAssertFalse(snapshot.monitoringActive)
+        XCTAssertEqual(snapshot.handlerCount, 0)
     }
 
     func test_ensureOfflineMonitoringActive_defaultsToSuppressingInitialEmission() {
@@ -1260,7 +1367,7 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
     }
 
     private func makeGeneratedRedirectCallbackUrl(
-        bundleIdentifier: String = Bundle.main.bundleIdentifier?.lowercased() ?? "com.frontegg.demo",
+        bundleIdentifier: String = currentAppBundleIdentifier(),
         host: String = "test.example.com",
         path: String = "/ios/oauth/callback",
         code: String? = nil,
@@ -1291,7 +1398,7 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
     }
 
     private func currentTestBundleIdentifier() -> String {
-        Bundle.main.bundleIdentifier?.lowercased() ?? "com.frontegg.demo"
+        currentAppBundleIdentifier()
     }
 
     private func waitForOAuthErrorDispatch() async {

--- a/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
@@ -325,17 +325,10 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
     }
 
     func test_handleSocialLoginCallback_errorCallback_returnsNil() {
-#if DEBUG
-        PlistHelper.testConfigOverride = makeSharedAppConfig()
-#endif
-        let app = FronteggApp.shared
-        let previousBaseUrl = app.baseUrl
-        let previousBundleIdentifier = app.bundleIdentifier
-        app.baseUrl = "https://test.example.com"
-        app.bundleIdentifier = "com.frontegg.demo"
+        let previousBaseUrl = auth.baseUrl
+        auth.baseUrl = "https://test.example.com"
         defer {
-            app.baseUrl = previousBaseUrl
-            app.bundleIdentifier = previousBundleIdentifier
+            auth.baseUrl = previousBaseUrl
         }
 
         let callbackUrl = makeGeneratedRedirectCallbackUrl(
@@ -345,6 +338,43 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         )
 
         XCTAssertNil(auth.handleSocialLoginCallback(callbackUrl))
+    }
+
+    func test_handleSocialLoginCallback_generatedRedirectAliasWithBasePath_preservesActualCallbackAlias() throws {
+        let bundleIdentifier = currentTestBundleIdentifier()
+        let previousBaseUrl = auth.baseUrl
+        auth.baseUrl = "https://test.example.com/fe-auth"
+        defer {
+            auth.baseUrl = previousBaseUrl
+        }
+
+        let rawSocialState = try makeRawSocialState(
+            provider: "google",
+            appId: "app-1",
+            action: "login"
+        )
+        let callbackUrl = makeGeneratedRedirectCallbackUrl(
+            bundleIdentifier: bundleIdentifier,
+            path: "/ios/oauth/callback",
+            code: "code-123",
+            state: rawSocialState
+        )
+
+        let finalUrl = auth.handleSocialLoginCallback(callbackUrl)
+        let queryItems = finalUrl.flatMap { getQueryItems($0.absoluteString) }
+
+        XCTAssertEqual(finalUrl?.path, "/fe-auth/oauth/account/social/success")
+        XCTAssertEqual(
+            queryItems?["redirectUri"],
+            "\(bundleIdentifier)://test.example.com/ios/oauth/callback"
+        )
+        let returnedState = queryItems?["state"]?.data(using: .utf8)
+        let returnedStateObject = returnedState.flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: String]
+        }
+        XCTAssertEqual(returnedStateObject?["provider"], "google")
+        XCTAssertEqual(returnedStateObject?["appId"], "app-1")
+        XCTAssertEqual(returnedStateObject?["action"], "login")
     }
 
     func test_handleSocialLoginOAuthCallback_errorCompletesFailure() async {
@@ -456,6 +486,46 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertEqual(delegate.contexts.first?.errorDescription, "JWT token size exceeded")
         XCTAssertEqual(delegate.contexts.first?.flow, .socialLogin)
         XCTAssertEqual(delegate.contexts.first?.embeddedMode, false)
+    }
+
+    func test_createOauthCallbackHandler_generatedRedirectAliasWithBasePath_usesActualCallbackAliasForExchange() async throws {
+        let accessToken = try makeAccessToken()
+        api.exchangeTokenResponse = try makeAuthResponse(
+            accessToken: accessToken,
+            refreshToken: "refresh-token-base-path"
+        )
+        api.meResult = .success(try makeUser())
+
+        let bundleIdentifier = currentTestBundleIdentifier()
+        let previousAuthBaseUrl = auth.baseUrl
+        auth.baseUrl = "https://test.example.com/fe-auth"
+        defer {
+            auth.baseUrl = previousAuthBaseUrl
+        }
+
+        CredentialManager.registerPendingOAuth(state: "expected-state", codeVerifier: "expected-verifier")
+
+        let result = await executeCallback(
+            allowFallback: false,
+            url: makeGeneratedRedirectCallbackUrl(
+                bundleIdentifier: bundleIdentifier,
+                path: "/ios/oauth/callback",
+                code: "code-123",
+                state: "expected-state"
+            )
+        )
+
+        switch result {
+        case .success(let user):
+            XCTAssertEqual(user.email, "test@example.com")
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+
+        XCTAssertEqual(
+            api.lastExchangeInput?.redirectUrl,
+            "\(bundleIdentifier)://test.example.com/ios/oauth/callback"
+        )
     }
 
     func test_getQueryItems_plusOnlyOAuthErrorValues_doNotProduceFailureDetails() {
@@ -965,6 +1035,27 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertTrue(NetworkStatusMonitor._testSnapshot().monitoringActive)
     }
 
+    func test_recheckConnection_unauthenticatedOffline_returnsToLoginStateWhenNetworkIsBack() async {
+        NetworkStatusMonitor._testSetReachabilityOverride(true)
+
+        auth.setIsAuthenticated(false)
+        auth.setUser(nil)
+        auth.setAccessToken(nil)
+        auth.setRefreshToken(nil)
+        auth.setIsOfflineMode(true)
+        auth.setIsLoading(false)
+        auth.setInitializing(false)
+
+        auth.recheckConnection()
+        for _ in 0..<20 where auth.isOfflineMode {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTAssertFalse(auth.isOfflineMode)
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertNil(auth.user)
+    }
+
     func test_ensureOfflineMonitoringActive_defaultsToSuppressingInitialEmission() {
         auth.ensureOfflineMonitoringActive()
 
@@ -1169,8 +1260,9 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
     }
 
     private func makeGeneratedRedirectCallbackUrl(
-        bundleIdentifier: String = "com.frontegg.demo",
+        bundleIdentifier: String = Bundle.main.bundleIdentifier?.lowercased() ?? "com.frontegg.demo",
         host: String = "test.example.com",
+        path: String = "/ios/oauth/callback",
         code: String? = nil,
         state: String? = nil,
         errorMessage: String? = nil,
@@ -1179,7 +1271,7 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         var components = URLComponents()
         components.scheme = bundleIdentifier.lowercased()
         components.host = host
-        components.path = "/ios/oauth/callback"
+        components.path = path
 
         var items: [URLQueryItem] = []
         if let code {
@@ -1196,6 +1288,10 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         }
         components.queryItems = items
         return components.url!
+    }
+
+    private func currentTestBundleIdentifier() -> String {
+        Bundle.main.bundleIdentifier?.lowercased() ?? "com.frontegg.demo"
     }
 
     private func waitForOAuthErrorDispatch() async {

--- a/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthOAuthCallbackTests.swift
@@ -1163,6 +1163,47 @@ final class FronteggAuthOAuthCallbackTests: XCTestCase {
         XCTAssertEqual(snapshot.handlerCount, 0)
     }
 
+    func test_recheckConnection_unauthenticatedOffline_ignoresStaleOfflineMonitorCacheWhenProbeSucceeds() async {
+        NetworkStatusMonitor._testSetReachabilityOverride(true)
+
+        auth.setIsAuthenticated(false)
+        auth.setUser(nil)
+        auth.setAccessToken(nil)
+        auth.setRefreshToken(nil)
+        auth.setIsOfflineMode(true)
+        auth.setIsLoading(false)
+        auth.setInitializing(false)
+        auth.ensureOfflineMonitoringActive()
+
+        // Simulate a stale cached offline result from background monitoring without
+        // letting a live path monitor race the manual Retry flow.
+        NetworkStatusMonitor.stopBackgroundMonitoring()
+        NetworkStatusMonitor._testSetState(
+            cachedReachable: false,
+            hasCachedReachable: true,
+            monitoringActive: true,
+            hasInitialCheckFired: true
+        )
+
+        let initialSnapshot = NetworkStatusMonitor._testSnapshot()
+        XCTAssertTrue(initialSnapshot.monitoringActive)
+        XCTAssertEqual(initialSnapshot.handlerCount, 1)
+        XCTAssertFalse(initialSnapshot.cachedReachable)
+        XCTAssertTrue(initialSnapshot.hasCachedReachable)
+
+        auth.recheckConnection()
+        for _ in 0..<20 where auth.isOfflineMode {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        let snapshot = NetworkStatusMonitor._testSnapshot()
+        XCTAssertFalse(auth.isOfflineMode)
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertNil(auth.user)
+        XCTAssertFalse(snapshot.monitoringActive)
+        XCTAssertEqual(snapshot.handlerCount, 0)
+    }
+
     func test_ensureOfflineMonitoringActive_defaultsToSuppressingInitialEmission() {
         auth.ensureOfflineMonitoringActive()
 

--- a/Tests/FronteggSwiftTests/LoggerDelegateTests.swift
+++ b/Tests/FronteggSwiftTests/LoggerDelegateTests.swift
@@ -175,10 +175,11 @@ final class LoggerDelegateTests: XCTestCase {
         weak var weakDelegate: SpyLoggerDelegate?
 
         autoreleasepool {
-            let delegate = SpyLoggerDelegate()
+            var delegate: SpyLoggerDelegate? = SpyLoggerDelegate()
             weakDelegate = delegate
             FeLogger.delegate = delegate
             XCTAssertNotNil(FeLogger.delegate)
+            delegate = nil  // Explicitly release the strong reference
         }
 
         XCTAssertNil(weakDelegate)

--- a/Tests/FronteggSwiftTests/LoggerDelegateTests.swift
+++ b/Tests/FronteggSwiftTests/LoggerDelegateTests.swift
@@ -174,7 +174,7 @@ final class LoggerDelegateTests: XCTestCase {
         logger.logLevel = .trace
         weak var weakDelegate: SpyLoggerDelegate?
 
-        do {
+        autoreleasepool {
             let delegate = SpyLoggerDelegate()
             weakDelegate = delegate
             FeLogger.delegate = delegate

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -147,4 +147,25 @@ final class NetworkStatusMonitorTests: XCTestCase {
         XCTAssertFalse(snapshot.monitoringActive)
         XCTAssertFalse(snapshot.hasInitialCheckFired)
     }
+
+    func test_staleMonitoringGeneration_doesNotNotifyHandlersAfterStop() {
+        let notCalled = expectation(description: "Stale monitoring generation should not notify")
+        notCalled.isInverted = true
+
+        NetworkStatusMonitor.startBackgroundMonitoring(emitInitialState: false)
+        let staleGeneration = NetworkStatusMonitor._testCurrentMonitoringGeneration()
+        NetworkStatusMonitor.stopBackgroundMonitoring()
+
+        _ = NetworkStatusMonitor.addOnChange { _ in
+            notCalled.fulfill()
+        }
+
+        NetworkStatusMonitor._testEmitCachedForMonitoringGeneration(
+            true,
+            expectedGeneration: staleGeneration,
+            forceEmit: true
+        )
+
+        wait(for: [notCalled], timeout: 0.2)
+    }
 }

--- a/Tests/FronteggSwiftTests/SocialLoginUrlGeneratorTests.swift
+++ b/Tests/FronteggSwiftTests/SocialLoginUrlGeneratorTests.swift
@@ -46,9 +46,11 @@ final class SocialLoginUrlGeneratorTests: XCTestCase {
             keepUserLoggedInAfterReinstall: false
         )
         FronteggApp.shared.manualInit(baseUrl: testBaseUrl, cliendId: testClientId)
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
     }
 
     override func tearDown() {
+        SocialLoginUrlGenerator.shared.clearPendingSocialCodeVerifiers()
         PlistHelper.testConfigOverride = nil
         super.tearDown()
     }
@@ -268,28 +270,67 @@ final class SocialLoginUrlGeneratorTests: XCTestCase {
         )
     }
 
-    func test_pendingCustomProviderCodeVerifier_isTrackedPerState() async {
+    func test_pendingSocialCodeVerifier_isTrackedPerState() {
         let firstState = "state-\(UUID().uuidString)"
         let secondState = "state-\(UUID().uuidString)"
 
-        await SocialLoginUrlGenerator.shared.storePendingCustomProviderCodeVerifier(
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
             "verifier-1",
             for: firstState
         )
-        await SocialLoginUrlGenerator.shared.storePendingCustomProviderCodeVerifier(
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
             "verifier-2",
             for: secondState
         )
 
-        let secondVerifier = await SocialLoginUrlGenerator.shared.consumePendingCustomProviderCodeVerifier(
-            for: secondState
-        )
-        let firstVerifier = await SocialLoginUrlGenerator.shared.consumePendingCustomProviderCodeVerifier(
-            for: firstState
-        )
+        let secondVerifier = SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: secondState)
+        let firstVerifier = SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: firstState)
 
         XCTAssertEqual(secondVerifier, "verifier-2")
         XCTAssertEqual(firstVerifier, "verifier-1")
+    }
+
+    func test_canonicalizeSocialState_removesBundleMetadata_deterministically() throws {
+        let rawState = try SocialLoginUrlGenerator.createState(
+            provider: .google,
+            appId: "app-1",
+            action: .login
+        )
+
+        let canonicalState = SocialLoginUrlGenerator.canonicalizeSocialState(rawState)
+        let data = try XCTUnwrap(canonicalState.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(
+            SocialLoginUrlGenerator.CanonicalOAuthState.self,
+            from: data
+        )
+
+        XCTAssertEqual(decoded.provider, "google")
+        XCTAssertEqual(decoded.appId, "app-1")
+        XCTAssertEqual(decoded.action, "login")
+        XCTAssertNil(decoded.oauthState)
+    }
+
+    func test_pendingSocialCodeVerifier_supportsRawAndCanonicalStateLookup() throws {
+        let rawState = try SocialLoginUrlGenerator.createState(
+            provider: .google,
+            appId: "app-2",
+            action: .login
+        )
+        let canonicalState = SocialLoginUrlGenerator.canonicalizeSocialState(rawState)
+
+        SocialLoginUrlGenerator.shared.storePendingSocialCodeVerifier(
+            "verifier-raw-canonical",
+            for: rawState
+        )
+
+        XCTAssertEqual(
+            SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: rawState),
+            "verifier-raw-canonical"
+        )
+        XCTAssertEqual(
+            SocialLoginUrlGenerator.shared.pendingSocialCodeVerifier(for: canonicalState),
+            "verifier-raw-canonical"
+        )
     }
 
     func test_codeVerifierInjectionScript_usesJSONStringLiteral() throws {

--- a/Tests/FronteggSwiftTests/SocialLoginUrlGeneratorTests.swift
+++ b/Tests/FronteggSwiftTests/SocialLoginUrlGeneratorTests.swift
@@ -189,6 +189,25 @@ final class SocialLoginUrlGeneratorTests: XCTestCase {
         XCTAssertEqual(decoded.provider, "custom-oauth")
     }
 
+    func test_createState_usesRuntimeBundleIdentifierOverride() throws {
+        let app = FronteggApp.shared
+        let previousBundleIdentifier = app.bundleIdentifier
+        defer { app.bundleIdentifier = previousBundleIdentifier }
+
+        app.bundleIdentifier = "Com.Override.Bundle"
+
+        let state = try SocialLoginUrlGenerator.createState(
+            provider: .google,
+            appId: "override-app-id",
+            action: .login
+        )
+
+        let data = try XCTUnwrap(state.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(SocialLoginUrlGenerator.OAuthState.self, from: data)
+
+        XCTAssertEqual(decoded.bundleId, "com.override.bundle")
+    }
+
     func test_authorizeURL_customProvider_matchesHostedStateAndGracefullySkipsPkceWithoutWebview() async throws {
         let provider = CustomSocialLoginProviderConfig(
             id: "e9a221f3-3d2a-413d-8183-dc9904fc70af",
@@ -267,6 +286,26 @@ final class SocialLoginUrlGeneratorTests: XCTestCase {
         XCTAssertEqual(
             uri,
             "\(testBaseUrl)/oauth/account/redirect/ios/\(FronteggApp.shared.bundleIdentifier)"
+        )
+    }
+
+    func test_defaultRedirectUri_usesRuntimeBundleIdentifierOverride() {
+        let app = FronteggApp.shared
+        let previousBaseUrl = FronteggAuth.shared.baseUrl
+        let previousBundleIdentifier = app.bundleIdentifier
+        defer {
+            FronteggAuth.shared.baseUrl = previousBaseUrl
+            app.bundleIdentifier = previousBundleIdentifier
+        }
+
+        FronteggAuth.shared.baseUrl = "https://override.example.com/fe-auth"
+        app.bundleIdentifier = "Com.Override.Bundle"
+
+        let uri = SocialLoginUrlGenerator.shared.defaultRedirectUri()
+
+        XCTAssertEqual(
+            uri,
+            "https://override.example.com/fe-auth/oauth/account/redirect/ios/com.override.bundle"
         )
     }
 

--- a/Tests/FronteggSwiftTests/UrlHelperTests.swift
+++ b/Tests/FronteggSwiftTests/UrlHelperTests.swift
@@ -67,6 +67,106 @@ final class UrlHelperTests: XCTestCase {
         XCTAssertNil(components)
     }
 
+    // MARK: - Generated redirect aliases
+
+    func test_supportedGeneratedRedirectUris_includeBasePathAndRootAlias_whenBaseUrlHasPath() {
+        let uris = supportedGeneratedRedirectUris(
+            baseUrl: "https://auth.example.com/fe-auth/",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(
+            uris,
+            [
+                "com.frontegg.demo://auth.example.com/fe-auth/ios/oauth/callback",
+                "com.frontegg.demo://auth.example.com/ios/oauth/callback",
+            ]
+        )
+    }
+
+    func test_generateRedirectUri_normalizesTrailingSlashInBasePath() {
+        let redirectUri = generateRedirectUri(
+            baseUrl: "https://auth.example.com/fe-auth/",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(
+            redirectUri,
+            "com.frontegg.demo://auth.example.com/fe-auth/ios/oauth/callback"
+        )
+    }
+
+    func test_supportedGeneratedRedirectUris_withoutBasePath_returnsOnlyCanonicalCallback() {
+        let uris = supportedGeneratedRedirectUris(
+            baseUrl: "https://auth.example.com",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(
+            uris,
+            [
+                "com.frontegg.demo://auth.example.com/ios/oauth/callback",
+            ]
+        )
+    }
+
+    func test_matchedGeneratedRedirectUri_acceptsRootAlias_whenBaseUrlHasPath() {
+        let callbackUrl = URL(string: "com.frontegg.demo://auth.example.com/ios/oauth/callback?code=123")!
+
+        let matched = matchedGeneratedRedirectUri(
+            callbackUrl,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(matched, "com.frontegg.demo://auth.example.com/ios/oauth/callback")
+    }
+
+    func test_matchedGeneratedRedirectUri_acceptsCanonicalBasePathCallback_whenBaseUrlHasPath() {
+        let callbackUrl = URL(string: "com.frontegg.demo://auth.example.com/fe-auth/ios/oauth/callback?code=123")!
+
+        let matched = matchedGeneratedRedirectUri(
+            callbackUrl,
+            baseUrl: "https://auth.example.com/fe-auth",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(matched, "com.frontegg.demo://auth.example.com/fe-auth/ios/oauth/callback")
+    }
+
+    func test_routedAppPath_stripsBasePathPrefix_forBaseUrlRoutes() {
+        let routedPath = routedAppPath(
+            URL(string: "https://auth.example.com/fe-auth/oauth/account/social/success?code=123")!,
+            baseUrl: "https://auth.example.com/fe-auth"
+        )
+
+        XCTAssertEqual(routedPath, "/oauth/account/social/success")
+    }
+
+    func test_getOverrideUrlType_treatsBasePathSocialSuccessAsLoginRoute() {
+        let app = FronteggApp.shared
+        let originalBaseUrl = app.baseUrl
+        defer { app.baseUrl = originalBaseUrl }
+
+        app.baseUrl = "https://auth.example.com/fe-auth"
+
+        let url = URL(string: "https://auth.example.com/fe-auth/oauth/account/social/success?code=123")!
+        XCTAssertEqual(getOverrideUrlType(url: url), .loginRoutes)
+    }
+
+    func test_getOverrideUrlType_treatsBasePathSocialPreloginAsSocialOauthPreLogin() {
+        let app = FronteggApp.shared
+        let originalBaseUrl = app.baseUrl
+        defer { app.baseUrl = originalBaseUrl }
+
+        app.baseUrl = "https://auth.example.com/fe-auth"
+
+        let url = URL(
+            string: "https://auth.example.com/fe-auth/frontegg/identity/resources/auth/v1/user/sso/default/google/prelogin"
+        )!
+        XCTAssertEqual(getOverrideUrlType(url: url), .SocialOauthPreLogin)
+    }
+
     // MARK: - isSocialLoginPath
 
     func test_isSocialLoginPath_returnsTrue_forIdentityPrelogin() {

--- a/Tests/FronteggSwiftTests/UrlHelperTests.swift
+++ b/Tests/FronteggSwiftTests/UrlHelperTests.swift
@@ -96,6 +96,34 @@ final class UrlHelperTests: XCTestCase {
         )
     }
 
+    func test_currentAppBundleIdentifier_prefersRuntimeOverrideWhenPresent() {
+        let app = FronteggApp.shared
+        let previousBundleIdentifier = app.bundleIdentifier
+        defer { app.bundleIdentifier = previousBundleIdentifier }
+
+        app.bundleIdentifier = "Com.Override.Bundle"
+
+        XCTAssertEqual(currentAppBundleIdentifier(), "com.override.bundle")
+    }
+
+    func test_generateRedirectUri_usesRuntimeBundleIdentifierOverride() {
+        let app = FronteggApp.shared
+        let previousBaseUrl = app.baseUrl
+        let previousBundleIdentifier = app.bundleIdentifier
+        defer {
+            app.baseUrl = previousBaseUrl
+            app.bundleIdentifier = previousBundleIdentifier
+        }
+
+        app.baseUrl = "https://auth.example.com/fe-auth"
+        app.bundleIdentifier = "Com.Override.Bundle"
+
+        XCTAssertEqual(
+            generateRedirectUri(),
+            "com.override.bundle://auth.example.com/fe-auth/ios/oauth/callback"
+        )
+    }
+
     func test_supportedGeneratedRedirectUris_withoutBasePath_returnsOnlyCanonicalCallback() {
         let uris = supportedGeneratedRedirectUris(
             baseUrl: "https://auth.example.com",

--- a/Tests/FronteggSwiftTests/UrlHelperTests.swift
+++ b/Tests/FronteggSwiftTests/UrlHelperTests.swift
@@ -7,6 +7,23 @@ import XCTest
 @testable import FronteggSwift
 
 final class UrlHelperTests: XCTestCase {
+    private let testBaseUrl = "https://auth.example.com"
+    private let testClientId = "test-url-helper-client"
+
+    override func setUp() {
+        super.setUp()
+        PlistHelper.testConfigOverride = FronteggPlist(
+            lateInit: true,
+            payload: .singleRegion(.init(baseUrl: testBaseUrl, clientId: testClientId)),
+            keepUserLoggedInAfterReinstall: false
+        )
+        FronteggApp.shared.manualInit(baseUrl: testBaseUrl, cliendId: testClientId)
+    }
+
+    override func tearDown() {
+        PlistHelper.testConfigOverride = nil
+        super.tearDown()
+    }
 
     // MARK: - getCallbackType
 
@@ -121,6 +138,30 @@ final class UrlHelperTests: XCTestCase {
         XCTAssertEqual(
             generateRedirectUri(),
             "com.override.bundle://auth.example.com/fe-auth/ios/oauth/callback"
+        )
+    }
+
+    func test_generateRedirectUri_returnsInvalidSentinel_whenBaseUrlCannotBeParsed() {
+        let redirectUri = generateRedirectUri(
+            baseUrl: "not a valid url",
+            bundleIdentifier: "com.frontegg.demo"
+        )
+
+        XCTAssertEqual(
+            redirectUri,
+            "com.frontegg.demo://invalid/ios/oauth/callback"
+        )
+    }
+
+    func test_generateRedirectUri_returnsDefaultInvalidSentinel_whenBundleIdentifierIsEmpty() {
+        let redirectUri = generateRedirectUri(
+            baseUrl: "not a valid url",
+            bundleIdentifier: ""
+        )
+
+        XCTAssertEqual(
+            redirectUri,
+            "frontegg-invalid://invalid/ios/oauth/callback"
         )
     }
 

--- a/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
+++ b/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
@@ -130,6 +130,109 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         waitForUserEmail("google-social@frontegg.com", timeout: 30)
     }
 
+    func testEmbeddedGoogleSocialLoginSupportsBasePathRootCallbackAlias() throws {
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth",
+            useRootGeneratedCallbackAlias: true
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+        waitForUserEmail("google-social@frontegg.com", timeout: 30)
+    }
+
+    func testEmbeddedGoogleSocialLoginSupportsBasePathCanonicalCallbackAlias() throws {
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth"
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+        waitForUserEmail("google-social@frontegg.com", timeout: 30)
+    }
+
+    func testEmbeddedGoogleSocialLoginDoesNotShowOAuthErrorToastOnSuccess() throws {
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth",
+            useRootGeneratedCallbackAlias: true
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+        waitForUserEmailWithoutOAuthError("google-social@frontegg.com", timeout: 30)
+    }
+
+    func testEmbeddedGoogleSocialLoginCompletesWhenExistingSessionRedirectsToDashboard() throws {
+        Self.server.queueEmbeddedSocialSuccessDashboardRedirect()
+
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth",
+            useRootGeneratedCallbackAlias: true
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+
+        XCTAssertTrue(
+            Self.server.waitForRequest(method: "POST", path: "/frontegg/oauth/authorize/silent", timeout: 20),
+            screenDebugSummary()
+        )
+        waitForUserEmailWithoutOAuthError("google-social@frontegg.com", timeout: 30)
+    }
+
+    func testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage() throws {
+        Self.server.queueEmbeddedSocialSuccessStall()
+
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth",
+            useRootGeneratedCallbackAlias: true
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+        waitForUserEmail("google-social@frontegg.com", timeout: 30)
+    }
+
     func testEmbeddedGoogleSocialLoginOAuthErrorShowsToastAndKeepsLoginOpen() throws {
         Self.server.queueEmbeddedSocialSuccessOAuthError(
             errorCode: "ER-05001",
@@ -352,6 +455,86 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         waitForScreen("NoConnectionPageRoot", timeout: 20)
 
         XCTAssertTrue(retryConnectionControl().exists, screenDebugSummary())
+        XCTAssertFalse(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
+    }
+
+    func testRetryFromUnauthenticatedOfflineScreenReturnsToLoginWhenNetworkRecovers() throws {
+        allowsUnexpectedNoConnectionScreen = true
+
+        Self.server.configureTokenPolicy(
+            email: "test@frontegg.com",
+            accessTokenTTL: expiringAccessTokenTTL,
+            refreshTokenTTL: longLivedRefreshTokenTTL
+        )
+
+        launchApp(resetState: true)
+        loginWithPassword()
+        Self.server.clearRequestLog()
+
+        waitUntilAccessTokenExpiresWithin(immediateRefreshTriggerWindow, timeout: 15)
+        let initialRefreshCount = refreshRequestCount()
+
+        try Self.server.queueProbeFailures(
+            statusCodes: Array(repeating: 503, count: 25)
+        )
+        try queueRefreshConnectionDrops()
+
+        tapGetCurrentAccessTokenButton()
+        waitForRefreshRecoveryFlowToStart(
+            refreshCountAtLeast: initialRefreshCount + 1,
+            timeout: 10
+        )
+        waitForRefreshRequestCount(atLeast: initialRefreshCount + 1, timeout: 10)
+        waitForAuthenticatedOfflineMode(true, timeout: 30)
+
+        tapButton("LogoutButton")
+        waitForScreen("NoConnectionPageRoot", timeout: 20)
+        try Self.server.reset()
+
+        let recoveryDeadline = Date().addingTimeInterval(10)
+        while Date() < recoveryDeadline {
+            if app.descendants(matching: .any)["LoginPageRoot"].exists {
+                break
+            }
+
+            let retryControl = retryConnectionControl()
+            if retryControl.exists {
+                retryControl.safeTap()
+                break
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+
+        waitForScreen("LoginPageRoot", timeout: 20)
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
+    }
+
+    func testOnlineLogoutReturnsToLoginWithoutOfflineScreen() throws {
+        launchApp(resetState: true)
+        loginWithPassword()
+
+        tapButton("LogoutButton")
+        waitForScreen("LoginPageRoot")
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
+    }
+
+    func testLogoutDuringTransientConnectivityLossRecoversBackToLoginWhenNetworkReturns() throws {
+        allowsUnexpectedNoConnectionScreen = true
+
+        launchApp(resetState: true)
+        loginWithPassword()
+
+        try Self.server.queueConnectionDrops(path: "/oauth/logout/token")
+        try Self.server.queueProbeFailures(statusCodes: Array(repeating: 503, count: 25))
+
+        tapButton("LogoutButton")
+        waitForScreen("NoConnectionPageRoot", timeout: 20)
+
+        try Self.server.reset()
+
+        waitForScreen("LoginPageRoot", timeout: 30)
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
         XCTAssertFalse(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
     }
 

--- a/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
+++ b/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
@@ -212,6 +212,32 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         waitForUserEmailWithoutOAuthError("google-social@frontegg.com", timeout: 30)
     }
 
+    func testEmbeddedGoogleSocialLoginCompletesWhenExistingSessionRedirectsToHostedRoot() throws {
+        Self.server.queueEmbeddedSocialSuccessRootRedirect()
+
+        launchApp(
+            resetState: true,
+            useTestingWebAuthenticationTransport: false,
+            basePathPrefix: "/fe-auth",
+            useRootGeneratedCallbackAlias: true
+        )
+        waitForScreen("LoginPageRoot")
+        tapButton("E2EEmbeddedGoogleSocialButton")
+
+        acceptSystemDialogIfNeeded(timeout: 10)
+        XCTAssertTrue(Self.server.waitForRequest(path: "/idp/google/authorize", timeout: 10))
+
+        app.getWebLabel("Mock Google Login").waitUntilExists(timeout: 20)
+        app.getWebButton("Continue with Mock Google").safeTap()
+        acceptSystemDialogIfNeeded(timeout: 10)
+
+        XCTAssertTrue(
+            Self.server.waitForRequest(method: "POST", path: "/frontegg/oauth/authorize/silent", timeout: 20),
+            screenDebugSummary()
+        )
+        waitForUserEmailWithoutOAuthError("google-social@frontegg.com", timeout: 30)
+    }
+
     func testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage() throws {
         Self.server.queueEmbeddedSocialSuccessStall()
 

--- a/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
+++ b/demo-embedded/demo-embedded-e2e/DemoEmbeddedE2ETests.swift
@@ -195,7 +195,7 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         XCTAssertTrue(app.staticTexts["AuthenticatedOfflineModeEnabled"].waitForExistence(timeout: 5), screenDebugSummary())
         XCTAssertTrue(app.staticTexts["OfflineModeBadge"].waitForExistence(timeout: 5), screenDebugSummary())
         XCTAssertEqual(accessTokenVersion(), initialVersion, screenDebugSummary())
-        XCTAssertFalse(app.buttons["RetryConnectionButton"].exists, screenDebugSummary())
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
     }
 
     func testExpiredAccessTokenRefreshesOnAuthenticatedRelaunch() throws {
@@ -221,7 +221,7 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         XCTAssertGreaterThan(refreshedVersion, initialVersion, screenDebugSummary())
         XCTAssertGreaterThan(refreshRequestCount(), initialRefreshCount, screenDebugSummary())
         XCTAssertFalse(app.staticTexts["AuthenticatedOfflineModeEnabled"].exists, screenDebugSummary())
-        XCTAssertFalse(app.buttons["RetryConnectionButton"].exists, screenDebugSummary())
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
     }
 
     func testAuthenticatedOfflineModeRecoversToOnlineAndRefreshesToken() throws {
@@ -251,7 +251,7 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         waitForRefreshRequestCount(atLeast: initialRefreshCount + 1, timeout: 10)
         waitForAuthenticatedOfflineMode(true, timeout: 30)
         XCTAssertTrue(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
-        XCTAssertFalse(app.buttons["RetryConnectionButton"].exists, screenDebugSummary())
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
 
         let recoveredVersion = waitForAccessTokenVersionChange(from: initialVersion, timeout: 25)
         waitForAuthenticatedOfflineMode(false, timeout: 10)
@@ -294,7 +294,7 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         waitForRefreshRequestCount(atLeast: initialRefreshCount + 1, timeout: 10)
         waitForAuthenticatedOfflineMode(true, timeout: 30)
         XCTAssertTrue(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
-        XCTAssertFalse(app.buttons["RetryConnectionButton"].exists, screenDebugSummary())
+        XCTAssertFalse(noConnectionScreen().exists, screenDebugSummary())
 
         let accessTokenExpiration = accessTokenExpiration()
         let secondsUntilExpiry = max(accessTokenExpiration - Int(Date().timeIntervalSince1970), 0)
@@ -316,6 +316,45 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
         XCTAssertTrue(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
     }
 
+    func testLogoutWhileAuthenticatedOfflineShowsNoConnectionPage() throws {
+        allowsUnexpectedNoConnectionScreen = true
+
+        Self.server.configureTokenPolicy(
+            email: "test@frontegg.com",
+            accessTokenTTL: expiringAccessTokenTTL,
+            refreshTokenTTL: longLivedRefreshTokenTTL
+        )
+
+        launchApp(resetState: true)
+        loginWithPassword()
+        Self.server.clearRequestLog()
+
+        waitUntilAccessTokenExpiresWithin(immediateRefreshTriggerWindow, timeout: 15)
+        let initialRefreshCount = refreshRequestCount()
+
+        try Self.server.queueProbeFailures(
+            statusCodes: Array(repeating: 503, count: 25)
+        )
+        try queueRefreshConnectionDrops()
+
+        tapGetCurrentAccessTokenButton()
+        waitForRefreshRecoveryFlowToStart(
+            refreshCountAtLeast: initialRefreshCount + 1,
+            timeout: 10
+        )
+        waitForRefreshRequestCount(atLeast: initialRefreshCount + 1, timeout: 10)
+        waitForAuthenticatedOfflineMode(true, timeout: 30)
+        try Self.server.queueProbeFailures(
+            statusCodes: Array(repeating: 503, count: 80)
+        )
+
+        tapButton("LogoutButton")
+        waitForScreen("NoConnectionPageRoot", timeout: 20)
+
+        XCTAssertTrue(retryConnectionControl().exists, screenDebugSummary())
+        XCTAssertFalse(app.staticTexts["UserEmailValue"].exists, screenDebugSummary())
+    }
+
     func testLogoutTerminateTransientNoConnectionThenCustomSSORecovers() throws {
         allowsUnexpectedNoConnectionScreen = true
         launchApp(resetState: true)
@@ -328,8 +367,8 @@ final class DemoEmbeddedE2ETests: DemoEmbeddedUITestCase {
 
         app.terminate()
         launchApp(resetState: false)
-        let noConnectionScreen = app.buttons["RetryConnectionButton"]
-        if noConnectionScreen.waitForExistence(timeout: 5) {
+        let noConnectionScreen = retryConnectionControl()
+        if noConnectionScreen.waitForExistence(timeout: 5) || self.noConnectionScreen().exists {
             waitForScreen("NoConnectionPageRoot")
             app.terminate()
             try Self.server.reset()

--- a/demo-embedded/demo-embedded-e2e/DemoEmbeddedUITestCase.swift
+++ b/demo-embedded/demo-embedded-e2e/DemoEmbeddedUITestCase.swift
@@ -2,7 +2,15 @@ import XCTest
 
 class DemoEmbeddedUITestCase: XCTestCase {
     static var server: LocalMockAuthServer!
-    private let knownScreenIdentifiers = ["LoginPageRoot", "NoConnectionPageRoot", "UserPageRoot", "AuthenticatedOfflineRoot"]
+    private let knownScreenIdentifiers = [
+        "LoginPageRoot",
+        "NoConnectionPageRoot",
+        "UserPageRoot",
+        "AuthenticatedOfflineRoot",
+        "BootstrapLoaderView",
+        "DefaultLoaderRoot",
+        "LoaderView",
+    ]
 
     var app: XCUIApplication!
     var allowsUnexpectedNoConnectionScreen = false
@@ -309,6 +317,7 @@ class DemoEmbeddedUITestCase: XCTestCase {
 
         let prominentTexts = [
             "Sign in",
+            "No Connection",
             "No internet connection",
             "Authenticated (offline)",
             "Welcome!",
@@ -335,6 +344,13 @@ class DemoEmbeddedUITestCase: XCTestCase {
             "isLoading": diagnosticValue(for: "AuthIsLoadingValue"),
             "offlineMarker": app.staticTexts["AuthenticatedOfflineModeEnabled"].exists ? "1" : "0",
             "message": diagnosticValue(for: "UserPageMessage"),
+            "rootAuth": diagnosticValue(for: "RootIsAuthenticatedValue"),
+            "rootOffline": diagnosticValue(for: "RootIsOfflineModeValue"),
+            "rootLoading": diagnosticValue(for: "RootIsLoadingValue"),
+            "rootInitializing": diagnosticValue(for: "RootInitializingValue"),
+            "rootShowLoader": diagnosticValue(for: "RootShowLoaderValue"),
+            "rootAppLink": diagnosticValue(for: "RootAppLinkValue"),
+            "rootHasUser": diagnosticValue(for: "RootHasUserValue"),
         ]
             .compactMap { key, value in value.map { "\(key)=\($0)" } }
             .joined(separator: ", ")
@@ -356,9 +372,27 @@ class DemoEmbeddedUITestCase: XCTestCase {
     }
 
     private func unexpectedNoConnectionScreenWasSeen() -> Bool {
-        let currentScreenVisible = app.buttons["RetryConnectionButton"].exists
+        let currentScreenVisible = noConnectionScreen().exists
         let stickyMarkerVisible = app.staticTexts["NoConnectionPageSeenEver"].exists
         return currentScreenVisible || stickyMarkerVisible
+    }
+
+    func noConnectionScreen() -> XCUIElement {
+        screenAnchor(for: "NoConnectionPageRoot")
+    }
+
+    func retryConnectionControl() -> XCUIElement {
+        let identifiedButton = app.buttons["RetryConnectionButton"]
+        if identifiedButton.exists {
+            return identifiedButton
+        }
+
+        let labeledButton = app.buttons["Retry"]
+        if labeledButton.exists {
+            return labeledButton
+        }
+
+        return identifiedButton
     }
 
     private func textValue(for identifier: String, timeout: TimeInterval) -> String {
@@ -395,24 +429,7 @@ class DemoEmbeddedUITestCase: XCTestCase {
     }
 
     private func screenAnchor(for identifier: String) -> XCUIElement {
-        switch identifier {
-        case "LoginPageRoot":
-            return app.buttons["NativeLoginButton"]
-        case "NoConnectionPageRoot":
-            return app.buttons["RetryConnectionButton"]
-        case "UserPageRoot":
-            return app.staticTexts["UserEmailValue"]
-        case "AuthenticatedOfflineRoot":
-            return app.staticTexts["Authenticated (offline)"]
-        case "BootstrapLoaderView":
-            return app.otherElements["BootstrapLoaderView"]
-        case "DefaultLoaderRoot":
-            return app.otherElements["DefaultLoaderRoot"]
-        case "LoaderView":
-            return app.otherElements["LoaderView"]
-        default:
-            return app.otherElements[identifier]
-        }
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 }
 

--- a/demo-embedded/demo-embedded-e2e/DemoEmbeddedUITestCase.swift
+++ b/demo-embedded/demo-embedded-e2e/DemoEmbeddedUITestCase.swift
@@ -44,14 +44,18 @@ class DemoEmbeddedUITestCase: XCTestCase {
         resetState: Bool = true,
         useTestingWebAuthenticationTransport: Bool = true,
         forceNetworkPathOffline: Bool = false,
-        enableOfflineMode: Bool? = nil
+        enableOfflineMode: Bool? = nil,
+        basePathPrefix: String = "",
+        useRootGeneratedCallbackAlias: Bool = false
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment = Self.server.launchEnvironment(
             resetState: resetState,
             useTestingWebAuthenticationTransport: useTestingWebAuthenticationTransport,
             forceNetworkPathOffline: forceNetworkPathOffline,
-            enableOfflineMode: enableOfflineMode
+            enableOfflineMode: enableOfflineMode,
+            basePathPrefix: basePathPrefix,
+            useRootGeneratedCallbackAlias: useRootGeneratedCallbackAlias
         )
         app.launch()
         self.app = app
@@ -86,6 +90,33 @@ class DemoEmbeddedUITestCase: XCTestCase {
         waitForScreen("UserPageRoot", timeout: timeout)
         XCTAssertTrue(app.staticTexts[email].waitForExistence(timeout: timeout), "Expected user email \(email)")
         assertNoUnexpectedNoConnectionScreenSeen()
+    }
+
+    func waitForUserEmailWithoutOAuthError(
+        _ email: String,
+        timeout: TimeInterval = 20,
+        postAppearanceGuard: TimeInterval = 2
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        let userPageRoot = app.descendants(matching: .any)["UserPageRoot"]
+        let emailLabel = app.staticTexts[email]
+
+        while Date() < deadline {
+            if oauthErrorToastIsVisible() {
+                XCTFail("Unexpected OAuth error toast appeared while waiting for user email \(email). \(screenDebugSummary())")
+                return
+            }
+
+            if userPageRoot.exists && emailLabel.exists {
+                assertNoOAuthErrorToastAppears(duration: postAppearanceGuard)
+                assertNoUnexpectedNoConnectionScreenSeen()
+                return
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+
+        XCTFail("Expected user email \(email) without OAuth error. \(screenDebugSummary())")
     }
 
     func assertNoConnectionScreenDoesNotAppear(duration: TimeInterval, pollInterval: TimeInterval = 0.1) {
@@ -219,6 +250,21 @@ class DemoEmbeddedUITestCase: XCTestCase {
 
         XCTFail("Expected OAuth error message containing '\(substring)' within \(timeout)s. \(screenDebugSummary())")
         return message
+    }
+
+    func assertNoOAuthErrorToastAppears(
+        duration: TimeInterval,
+        pollInterval: TimeInterval = 0.1
+    ) {
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            if oauthErrorToastIsVisible() {
+                XCTFail("Unexpected OAuth error toast appeared. \(screenDebugSummary())")
+                return
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        }
     }
 
     func waitForDuration(_ duration: TimeInterval, pollInterval: TimeInterval = 0.1) {
@@ -377,22 +423,33 @@ class DemoEmbeddedUITestCase: XCTestCase {
         return currentScreenVisible || stickyMarkerVisible
     }
 
+    private func oauthErrorToastIsVisible() -> Bool {
+        let candidates: [XCUIElement] = [
+            app.descendants(matching: .any).matching(identifier: "OAuthErrorToast").firstMatch,
+            app.staticTexts["OAuthErrorToast"],
+            app.otherElements["OAuthErrorToast"],
+        ]
+
+        return candidates.contains { $0.exists }
+    }
+
     func noConnectionScreen() -> XCUIElement {
         screenAnchor(for: "NoConnectionPageRoot")
     }
 
     func retryConnectionControl() -> XCUIElement {
-        let identifiedButton = app.buttons["RetryConnectionButton"]
-        if identifiedButton.exists {
-            return identifiedButton
+        let candidates: [XCUIElement] = [
+            app.buttons["RetryConnectionButton"],
+            app.buttons["Retry"],
+            app.otherElements["RetryConnectionButton"],
+            app.otherElements["Retry"],
+        ]
+
+        for candidate in candidates where candidate.exists {
+            return candidate
         }
 
-        let labeledButton = app.buttons["Retry"]
-        if labeledButton.exists {
-            return labeledButton
-        }
-
-        return identifiedButton
+        return candidates[0]
     }
 
     private func textValue(for identifier: String, timeout: TimeInterval) -> String {

--- a/demo-embedded/demo-embedded-e2e/LocalMockAuthServer.swift
+++ b/demo-embedded/demo-embedded-e2e/LocalMockAuthServer.swift
@@ -7,9 +7,12 @@ final class LocalMockAuthServer {
     private let listenerQueue = DispatchQueue(label: "com.frontegg.demo-embedded-e2e.mock-server")
     private let state = MockAuthState()
     private let requestLogLock = NSLock()
+    private let configurationLock = NSLock()
     private var requestLog: [LoggedRequest] = []
     private let port: UInt16 = 49381
     private var listener: NWListener?
+    private var configuredBasePathPrefix: String = ""
+    private var useRootGeneratedCallbackAlias: Bool = false
 
     let clientId = "demo-embedded-e2e-client"
     let baseURL = URL(string: "http://127.0.0.1:49381")!
@@ -77,16 +80,26 @@ final class LocalMockAuthServer {
         resetState: Bool,
         useTestingWebAuthenticationTransport: Bool = true,
         forceNetworkPathOffline: Bool = false,
-        enableOfflineMode: Bool? = nil
+        enableOfflineMode: Bool? = nil,
+        basePathPrefix: String = "",
+        useRootGeneratedCallbackAlias: Bool = false
     ) -> [String: String] {
+        let normalizedBasePathPrefix = normalizeBasePathPrefix(basePathPrefix)
+        let appBaseURL = configuredAppBaseURL(basePathPrefix: normalizedBasePathPrefix)
+
+        configurationLock.lock()
+        configuredBasePathPrefix = normalizedBasePathPrefix
+        self.useRootGeneratedCallbackAlias = useRootGeneratedCallbackAlias
+        configurationLock.unlock()
+
         var env: [String: String] = [
             "frontegg-testing": "true",
-            "FRONTEGG_E2E_BASE_URL": baseURL.absoluteString,
+            "FRONTEGG_E2E_BASE_URL": appBaseURL.absoluteString,
             "FRONTEGG_E2E_CLIENT_ID": clientId,
             "FRONTEGG_E2E_RESET_STATE": resetState ? "1" : "0",
             "FRONTEGG_E2E_FORCE_NETWORK_PATH_OFFLINE": forceNetworkPathOffline ? "1" : "0",
             "FRONTEGG_TEST_WEB_AUTH_TRANSPORT": useTestingWebAuthenticationTransport ? "1" : "0",
-            "FRONTEGG_TEST_SOCIAL_AUTHORIZE_URL_GOOGLE": "\(baseURL.absoluteString)/idp/google/authorize",
+            "FRONTEGG_TEST_SOCIAL_AUTHORIZE_URL_GOOGLE": "\(appBaseURL.absoluteString)/idp/google/authorize",
         ]
         if let enableOfflineMode {
             env["FRONTEGG_E2E_ENABLE_OFFLINE_MODE"] = enableOfflineMode ? "1" : "0"
@@ -97,6 +110,10 @@ final class LocalMockAuthServer {
     func reset() throws {
         state.reset()
         clearRequestLog()
+        configurationLock.lock()
+        configuredBasePathPrefix = ""
+        useRootGeneratedCallbackAlias = false
+        configurationLock.unlock()
     }
 
     func clearRequestLog() {
@@ -166,6 +183,14 @@ final class LocalMockAuthServer {
             errorCode: errorCode,
             errorDescription: errorDescription
         )
+    }
+
+    func queueEmbeddedSocialSuccessStall(count: Int = 1) {
+        state.queueEmbeddedSocialSuccessStall(count: count)
+    }
+
+    func queueEmbeddedSocialSuccessDashboardRedirect(count: Int = 1) {
+        state.queueEmbeddedSocialSuccessDashboardRedirect(count: count)
     }
 
     func waitForRequest(
@@ -289,7 +314,7 @@ final class LocalMockAuthServer {
         let body = buffer.subdata(in: bodyStart..<(bodyStart + contentLength))
         let targetURLString = target.hasPrefix("http") ? target : "http://127.0.0.1\(target)"
         let components = URLComponents(string: targetURLString)
-        let path = normalizePath(components?.path ?? "/")
+        let path = routedPath(components?.path ?? "/")
 
         var query: [String: [String]] = [:]
         for item in components?.queryItems ?? [] {
@@ -475,7 +500,7 @@ final class LocalMockAuthServer {
             loginHint: loginHint
         )
 
-        var components = URLComponents(url: baseURL.appendingPathComponent("oauth/prelogin"), resolvingAgainstBaseURL: false)
+        var components = URLComponents(url: currentAppBaseURL().appendingPathComponent("oauth/prelogin"), resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "redirect_uri", value: redirectURI),
@@ -485,7 +510,7 @@ final class LocalMockAuthServer {
             components?.queryItems?.append(URLQueryItem(name: "login_hint", value: loginHint))
         }
 
-        return redirectResponse(location: components?.string ?? "\(baseURL.absoluteString)/oauth/prelogin?state=\(hostedState)")
+        return redirectResponse(location: components?.string ?? "\(currentAppBaseURL().absoluteString)/oauth/prelogin?state=\(hostedState)")
     }
 
     private func handleHostedPrelogin(query: [String: [String]]) -> HTTPResponse {
@@ -881,8 +906,8 @@ final class LocalMockAuthServer {
                 "active": true,
                 "customised": false,
                 "clientId": "mock-google-client-id",
-                "redirectUrl": "\(baseURL.absoluteString)/oauth/account/social/success",
-                "redirectUrlPattern": "\(baseURL.absoluteString)/oauth/account/social/success",
+                "redirectUrl": "\(currentAppBaseURL().absoluteString)/oauth/account/social/success",
+                "redirectUrlPattern": "\(currentAppBaseURL().absoluteString)/oauth/account/social/success",
                 "options": [
                     "verifyEmail": false,
                 ],
@@ -1045,7 +1070,7 @@ final class LocalMockAuthServer {
     }
 
     private func handleMockGoogleAuthorize(query: [String: [String]]) -> HTTPResponse {
-        let redirectURI = firstValue(query, key: "redirect_uri")
+        let redirectURI = rewrittenGeneratedCallbackRedirectURI(firstValue(query, key: "redirect_uri"))
         let stateValue = firstValue(query, key: "state")
         guard !redirectURI.isEmpty, !stateValue.isEmpty else {
             return htmlResponse(status: 400, title: "Invalid mock Google request", body: "<h1>Invalid mock Google request</h1>")
@@ -1100,6 +1125,23 @@ final class LocalMockAuthServer {
         let redirectURI = firstValue(query, key: "redirectUri")
         guard !redirectURI.isEmpty else {
             return jsonResponse(status: 400, payload: ["error": "missing_social_redirect_uri"])
+        }
+
+        if state.consumeEmbeddedSocialSuccessDashboardRedirect() {
+            let issuedRefreshToken = state.issueRefreshToken(email: "google-social@frontegg.com")
+            let cookieValue = "fe_refresh_demo_embedded_e2e=\(issuedRefreshToken.token); Path=/; HttpOnly; SameSite=Lax"
+            return redirectResponse(
+                location: currentAppBaseURL().appendingPathComponent("dashboard").absoluteString,
+                additionalHeaders: ["Set-Cookie": cookieValue]
+            )
+        }
+
+        if state.consumeEmbeddedSocialSuccessStall() {
+            return HTTPResponse(
+                statusCode: 200,
+                headers: ["Content-Type": "text/html; charset=utf-8"],
+                body: Data("<!DOCTYPE html><html><body style='background:#fff'></body></html>".utf8)
+            )
         }
 
         if let pendingError = state.consumeEmbeddedSocialSuccessOAuthError() {
@@ -1328,10 +1370,15 @@ final class LocalMockAuthServer {
         )
     }
 
-    private func redirectResponse(location: String) -> HTTPResponse {
-        HTTPResponse(
+    private func redirectResponse(
+        location: String,
+        additionalHeaders: [String: String] = [:]
+    ) -> HTTPResponse {
+        var headers = ["Location": location]
+        additionalHeaders.forEach { headers[$0.key] = $0.value }
+        return HTTPResponse(
             statusCode: 302,
-            headers: ["Location": location],
+            headers: headers,
             body: Data()
         )
     }
@@ -1379,7 +1426,7 @@ final class LocalMockAuthServer {
         var components = URLComponents()
         components.scheme = bundleIdentifier.lowercased()
         components.host = baseURL.host
-        components.path = "/ios/oauth/callback"
+        components.path = generatedRedirectCallbackPath()
 
         var queryItems = [
             URLQueryItem(name: "error", value: error),
@@ -1389,7 +1436,7 @@ final class LocalMockAuthServer {
             queryItems.append(URLQueryItem(name: "state", value: state))
         }
         components.queryItems = queryItems
-        return components.string ?? "\(bundleIdentifier.lowercased())://\(baseURL.host ?? "")/ios/oauth/callback"
+        return components.string ?? "\(bundleIdentifier.lowercased())://\(baseURL.host ?? "")\(generatedRedirectCallbackPath())"
     }
 
     private func buildGeneratedRedirectCodeCallbackURL(
@@ -1400,13 +1447,13 @@ final class LocalMockAuthServer {
         var components = URLComponents()
         components.scheme = bundleIdentifier.lowercased()
         components.host = baseURL.host
-        components.path = "/ios/oauth/callback"
+        components.path = generatedRedirectCallbackPath()
         components.queryItems = [
             URLQueryItem(name: "state", value: state),
             URLQueryItem(name: "code", value: code),
             URLQueryItem(name: "social-login-callback", value: "true")
         ]
-        return components.string ?? "\(bundleIdentifier.lowercased())://\(baseURL.host ?? "")/ios/oauth/callback"
+        return components.string ?? "\(bundleIdentifier.lowercased())://\(baseURL.host ?? "")\(generatedRedirectCallbackPath())"
     }
 
     private func parseJSONDictionary(_ data: Data) -> [String: Any] {
@@ -1600,10 +1647,98 @@ final class LocalMockAuthServer {
         query[key]?.first ?? defaultValue
     }
 
+    private func normalizeBasePathPrefix(_ path: String) -> String {
+        guard !path.isEmpty, path != "/" else { return "" }
+
+        var normalized = path
+        if !normalized.hasPrefix("/") {
+            normalized = "/\(normalized)"
+        }
+
+        while normalized.count > 1 && normalized.hasSuffix("/") {
+            normalized.removeLast()
+        }
+
+        return normalized
+    }
+
+    private func configuredAppBaseURL(basePathPrefix: String) -> URL {
+        guard !basePathPrefix.isEmpty else {
+            return baseURL
+        }
+
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        components?.path = basePathPrefix
+        return components?.url ?? baseURL
+    }
+
+    private func currentAppBaseURL() -> URL {
+        configurationLock.lock()
+        let basePathPrefix = configuredBasePathPrefix
+        configurationLock.unlock()
+        return configuredAppBaseURL(basePathPrefix: basePathPrefix)
+    }
+
     private func normalizePath(_ path: String) -> String {
         if path.isEmpty { return "/" }
         if path.hasPrefix("/") { return path }
         return "/\(path)"
+    }
+
+    private func routedPath(_ rawPath: String) -> String {
+        let normalized = normalizePath(rawPath)
+        configurationLock.lock()
+        let basePathPrefix = configuredBasePathPrefix
+        configurationLock.unlock()
+
+        guard !basePathPrefix.isEmpty else {
+            return normalized
+        }
+
+        if normalized == basePathPrefix {
+            return "/"
+        }
+
+        let prefixWithSlash = "\(basePathPrefix)/"
+        if normalized.hasPrefix(prefixWithSlash) {
+            return "/\(normalized.dropFirst(prefixWithSlash.count))"
+        }
+
+        return normalized
+    }
+
+    private func generatedRedirectCallbackPath() -> String {
+        configurationLock.lock()
+        let configuration = (configuredBasePathPrefix, useRootGeneratedCallbackAlias)
+        configurationLock.unlock()
+
+        if !configuration.0.isEmpty && !configuration.1 {
+            return "\(configuration.0)/ios/oauth/callback"
+        }
+
+        return "/ios/oauth/callback"
+    }
+
+    private func rewrittenGeneratedCallbackRedirectURI(_ redirectURI: String) -> String {
+        configurationLock.lock()
+        let configuration = (configuredBasePathPrefix, useRootGeneratedCallbackAlias)
+        configurationLock.unlock()
+
+        guard configuration.1, !configuration.0.isEmpty else {
+            return redirectURI
+        }
+
+        guard var components = URLComponents(string: redirectURI) else {
+            return redirectURI
+        }
+
+        let canonicalPath = "\(configuration.0)/ios/oauth/callback"
+        guard components.path == canonicalPath else {
+            return redirectURI
+        }
+
+        components.path = "/ios/oauth/callback"
+        return components.string ?? redirectURI
     }
 
     private func htmlEscaped(_ string: String) -> String {
@@ -1758,6 +1893,8 @@ private final class MockAuthState {
     private var refreshTokens: [String: RefreshTokenRecord] = [:]
     private var tokenPolicies: [String: TokenPolicy] = [:]
     private var pendingEmbeddedSocialSuccessOAuthError: PendingEmbeddedSocialSuccessOAuthError?
+    private var pendingEmbeddedSocialSuccessStallCount: Int = 0
+    private var pendingEmbeddedSocialSuccessDashboardRedirectCount: Int = 0
 
     init() {
         reset()
@@ -1779,6 +1916,8 @@ private final class MockAuthState {
                 ),
             ]
             pendingEmbeddedSocialSuccessOAuthError = nil
+            pendingEmbeddedSocialSuccessStallCount = 0
+            pendingEmbeddedSocialSuccessDashboardRedirectCount = 0
         }
     }
 
@@ -1926,11 +2065,47 @@ private final class MockAuthState {
         }
     }
 
+    func queueEmbeddedSocialSuccessStall(count: Int) {
+        queue.sync {
+            pendingEmbeddedSocialSuccessStallCount += count
+        }
+    }
+
+    func queueEmbeddedSocialSuccessDashboardRedirect(count: Int) {
+        guard count > 0 else { return }
+
+        queue.sync {
+            pendingEmbeddedSocialSuccessDashboardRedirectCount += count
+        }
+    }
+
     func consumeEmbeddedSocialSuccessOAuthError() -> PendingEmbeddedSocialSuccessOAuthError? {
         queue.sync {
             let pendingError = pendingEmbeddedSocialSuccessOAuthError
             pendingEmbeddedSocialSuccessOAuthError = nil
             return pendingError
+        }
+    }
+
+    func consumeEmbeddedSocialSuccessStall() -> Bool {
+        queue.sync {
+            guard pendingEmbeddedSocialSuccessStallCount > 0 else {
+                return false
+            }
+
+            pendingEmbeddedSocialSuccessStallCount -= 1
+            return true
+        }
+    }
+
+    func consumeEmbeddedSocialSuccessDashboardRedirect() -> Bool {
+        queue.sync {
+            guard pendingEmbeddedSocialSuccessDashboardRedirectCount > 0 else {
+                return false
+            }
+
+            pendingEmbeddedSocialSuccessDashboardRedirectCount -= 1
+            return true
         }
     }
 

--- a/demo-embedded/demo-embedded-e2e/LocalMockAuthServer.swift
+++ b/demo-embedded/demo-embedded-e2e/LocalMockAuthServer.swift
@@ -193,6 +193,10 @@ final class LocalMockAuthServer {
         state.queueEmbeddedSocialSuccessDashboardRedirect(count: count)
     }
 
+    func queueEmbeddedSocialSuccessRootRedirect(count: Int = 1) {
+        state.queueEmbeddedSocialSuccessRootRedirect(count: count)
+    }
+
     func waitForRequest(
         method: String? = nil,
         path: String,
@@ -1136,6 +1140,15 @@ final class LocalMockAuthServer {
             )
         }
 
+        if state.consumeEmbeddedSocialSuccessRootRedirect() {
+            let issuedRefreshToken = state.issueRefreshToken(email: "google-social@frontegg.com")
+            let cookieValue = "fe_refresh_demo_embedded_e2e=\(issuedRefreshToken.token); Path=/; HttpOnly; SameSite=Lax"
+            return redirectResponse(
+                location: currentAppBaseURL().absoluteString,
+                additionalHeaders: ["Set-Cookie": cookieValue]
+            )
+        }
+
         if state.consumeEmbeddedSocialSuccessStall() {
             return HTTPResponse(
                 statusCode: 200,
@@ -1895,6 +1908,7 @@ private final class MockAuthState {
     private var pendingEmbeddedSocialSuccessOAuthError: PendingEmbeddedSocialSuccessOAuthError?
     private var pendingEmbeddedSocialSuccessStallCount: Int = 0
     private var pendingEmbeddedSocialSuccessDashboardRedirectCount: Int = 0
+    private var pendingEmbeddedSocialSuccessRootRedirectCount: Int = 0
 
     init() {
         reset()
@@ -1918,6 +1932,7 @@ private final class MockAuthState {
             pendingEmbeddedSocialSuccessOAuthError = nil
             pendingEmbeddedSocialSuccessStallCount = 0
             pendingEmbeddedSocialSuccessDashboardRedirectCount = 0
+            pendingEmbeddedSocialSuccessRootRedirectCount = 0
         }
     }
 
@@ -2079,6 +2094,14 @@ private final class MockAuthState {
         }
     }
 
+    func queueEmbeddedSocialSuccessRootRedirect(count: Int) {
+        guard count > 0 else { return }
+
+        queue.sync {
+            pendingEmbeddedSocialSuccessRootRedirectCount += count
+        }
+    }
+
     func consumeEmbeddedSocialSuccessOAuthError() -> PendingEmbeddedSocialSuccessOAuthError? {
         queue.sync {
             let pendingError = pendingEmbeddedSocialSuccessOAuthError
@@ -2105,6 +2128,17 @@ private final class MockAuthState {
             }
 
             pendingEmbeddedSocialSuccessDashboardRedirectCount -= 1
+            return true
+        }
+    }
+
+    func consumeEmbeddedSocialSuccessRootRedirect() -> Bool {
+        queue.sync {
+            guard pendingEmbeddedSocialSuccessRootRedirectCount > 0 else {
+                return false
+            }
+
+            pendingEmbeddedSocialSuccessRootRedirectCount -= 1
             return true
         }
     }

--- a/demo-embedded/demo-embedded-e2e/scenario-catalog.json
+++ b/demo-embedded/demo-embedded-e2e/scenario-catalog.json
@@ -36,6 +36,16 @@
       "description": "Runs the embedded Google social flow through the real system web authentication session and verifies the Google social user is signed in."
     },
     {
+      "method": "testEmbeddedGoogleSocialLoginDoesNotShowOAuthErrorToastOnSuccess",
+      "title": "Embedded Google social success shows no OAuth error toast",
+      "description": "Runs the embedded Google social flow through the base-path callback alias and verifies the user signs in without any stale OAuth error toast appearing."
+    },
+    {
+      "method": "testEmbeddedGoogleSocialLoginCompletesWhenExistingSessionRedirectsToDashboard",
+      "title": "Embedded Google social login completes when an existing session redirects to dashboard",
+      "description": "Queues the existing-session dashboard redirect path after social success, verifies the SDK extracts the hosted refresh cookie, and confirms the user still signs in."
+    },
+    {
       "method": "testEmbeddedGoogleSocialLoginOAuthErrorShowsToastAndKeepsLoginOpen",
       "title": "Embedded Google OAuth error keeps login open",
       "description": "Queues an OAuth error from the Google social callback, verifies the OAuth error toast is shown, and confirms the login UI stays open without authenticating the user."
@@ -74,6 +84,11 @@
       "method": "testLogoutWhileAuthenticatedOfflineShowsNoConnectionPage",
       "title": "Logout from authenticated offline mode shows the custom no-connection page",
       "description": "Forces authenticated offline mode, logs out, and verifies the app lands on the unauthenticated custom no-connection screen instead of a hosted error or stuck transition."
+    },
+    {
+      "method": "testLogoutDuringTransientConnectivityLossRecoversBackToLoginWhenNetworkReturns",
+      "title": "Logout during transient connectivity loss recovers back to login",
+      "description": "Drops connectivity during logout, verifies the app can enter the custom no-connection state, then restores connectivity and confirms the app recovers back to the login screen without a stuck blank state."
     },
     {
       "method": "testLogoutTerminateTransientNoConnectionThenCustomSSORecovers",

--- a/demo-embedded/demo-embedded-e2e/scenario-catalog.json
+++ b/demo-embedded/demo-embedded-e2e/scenario-catalog.json
@@ -56,6 +56,11 @@
       "description": "Queues the existing-session dashboard redirect path after social success, verifies the SDK extracts the hosted refresh cookie, and confirms the user still signs in."
     },
     {
+      "method": "testEmbeddedGoogleSocialLoginCompletesWhenExistingSessionRedirectsToHostedRoot",
+      "title": "Embedded Google social login completes when an existing session redirects to hosted root",
+      "description": "Queues the existing-session hosted-root redirect path after social success in a base-path deployment, verifies the SDK still recovers the hosted session, and confirms the user signs in."
+    },
+    {
       "method": "testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage",
       "title": "Embedded Google social login recovers from a stalled social success page",
       "description": "Queues a blank embedded social-success page after the system web authentication session closes and verifies the SDK recovers and completes login."

--- a/demo-embedded/demo-embedded-e2e/scenario-catalog.json
+++ b/demo-embedded/demo-embedded-e2e/scenario-catalog.json
@@ -36,6 +36,16 @@
       "description": "Runs the embedded Google social flow through the real system web authentication session and verifies the Google social user is signed in."
     },
     {
+      "method": "testEmbeddedGoogleSocialLoginSupportsBasePathRootCallbackAlias",
+      "title": "Embedded Google social login supports the root callback alias",
+      "description": "Runs the embedded Google social flow with a base-path deployment and verifies the login succeeds when the callback returns through the root /ios/oauth/callback alias."
+    },
+    {
+      "method": "testEmbeddedGoogleSocialLoginSupportsBasePathCanonicalCallbackAlias",
+      "title": "Embedded Google social login supports the canonical base-path callback",
+      "description": "Runs the embedded Google social flow with a base-path deployment and verifies the login succeeds when the callback returns through the canonical base-path callback URL."
+    },
+    {
       "method": "testEmbeddedGoogleSocialLoginDoesNotShowOAuthErrorToastOnSuccess",
       "title": "Embedded Google social success shows no OAuth error toast",
       "description": "Runs the embedded Google social flow through the base-path callback alias and verifies the user signs in without any stale OAuth error toast appearing."
@@ -44,6 +54,11 @@
       "method": "testEmbeddedGoogleSocialLoginCompletesWhenExistingSessionRedirectsToDashboard",
       "title": "Embedded Google social login completes when an existing session redirects to dashboard",
       "description": "Queues the existing-session dashboard redirect path after social success, verifies the SDK extracts the hosted refresh cookie, and confirms the user still signs in."
+    },
+    {
+      "method": "testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage",
+      "title": "Embedded Google social login recovers from a stalled social success page",
+      "description": "Queues a blank embedded social-success page after the system web authentication session closes and verifies the SDK recovers and completes login."
     },
     {
       "method": "testEmbeddedGoogleSocialLoginOAuthErrorShowsToastAndKeepsLoginOpen",
@@ -84,6 +99,16 @@
       "method": "testLogoutWhileAuthenticatedOfflineShowsNoConnectionPage",
       "title": "Logout from authenticated offline mode shows the custom no-connection page",
       "description": "Forces authenticated offline mode, logs out, and verifies the app lands on the unauthenticated custom no-connection screen instead of a hosted error or stuck transition."
+    },
+    {
+      "method": "testRetryFromUnauthenticatedOfflineScreenReturnsToLoginWhenNetworkRecovers",
+      "title": "Retry from the unauthenticated offline screen returns to login",
+      "description": "Forces unauthenticated offline mode, restores connectivity, taps Retry if needed, and verifies the app clears the custom no-connection screen and returns to login."
+    },
+    {
+      "method": "testOnlineLogoutReturnsToLoginWithoutOfflineScreen",
+      "title": "Online logout returns to login without showing offline UI",
+      "description": "Logs out while connectivity is healthy and verifies the app returns directly to the login screen without briefly sticking on the custom no-connection UI."
     },
     {
       "method": "testLogoutDuringTransientConnectivityLossRecoversBackToLoginWhenNetworkReturns",

--- a/demo-embedded/demo-embedded-e2e/scenario-catalog.json
+++ b/demo-embedded/demo-embedded-e2e/scenario-catalog.json
@@ -71,6 +71,11 @@
       "description": "Forces a prolonged offline window, lets the access token expire while offline, verifies the user stays signed in, and verifies reconnect refreshes the token successfully."
     },
     {
+      "method": "testLogoutWhileAuthenticatedOfflineShowsNoConnectionPage",
+      "title": "Logout from authenticated offline mode shows the custom no-connection page",
+      "description": "Forces authenticated offline mode, logs out, and verifies the app lands on the unauthenticated custom no-connection screen instead of a hosted error or stuck transition."
+    },
+    {
       "method": "testLogoutTerminateTransientNoConnectionThenCustomSSORecovers",
       "title": "Custom SSO recovers after a transient no-connection relaunch",
       "description": "Logs out, relaunches through a transient no-connection state if it appears, then completes custom SSO and verifies the user is signed in again."

--- a/demo-embedded/demo-embedded/MyApp.swift
+++ b/demo-embedded/demo-embedded/MyApp.swift
@@ -73,6 +73,34 @@ struct MyApp: View {
                             : "UnauthenticatedOfflineModeEnabled"
                     )
                 }
+                ScreenValueMarker(
+                    identifier: "RootIsAuthenticatedValue",
+                    value: fronteggAuth.isAuthenticated ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootIsOfflineModeValue",
+                    value: fronteggAuth.isOfflineMode ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootIsLoadingValue",
+                    value: fronteggAuth.isLoading ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootInitializingValue",
+                    value: fronteggAuth.initializing ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootShowLoaderValue",
+                    value: fronteggAuth.showLoader ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootAppLinkValue",
+                    value: fronteggAuth.appLink ? "1" : "0"
+                )
+                ScreenValueMarker(
+                    identifier: "RootHasUserValue",
+                    value: fronteggAuth.user != nil ? "1" : "0"
+                )
             }
         }.onAppear() {
             fronteggAuth.$accessToken.sink { accessToken in
@@ -98,6 +126,18 @@ private struct ScreenMarker: View {
 
     var body: some View {
         Text(identifier)
+            .font(.system(size: 1))
+            .foregroundColor(.clear)
+            .accessibilityIdentifier(identifier)
+    }
+}
+
+private struct ScreenValueMarker: View {
+    let identifier: String
+    let value: String
+
+    var body: some View {
+        Text(value)
             .font(.system(size: 1))
             .foregroundColor(.clear)
             .accessibilityIdentifier(identifier)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This repository includes:
 - An [API Reference](https://ios-swift-guide.frontegg.com/#/api) for detailed SDK functionality
 - [Usage Examples](https://ios-swift-guide.frontegg.com/#/usage) with common implementation patterns
 - [Advanced Topics](https://ios-swift-guide.frontegg.com/#/advanced) for complex integration scenarios
+- An [Offline Mode](https://ios-swift-guide.frontegg.com/#/offline-mode) guide for custom offline UI, reconnect behavior, and logout expectations
 - A [Hosted](https://github.com/frontegg/frontegg-ios-swift/tree/master/demo), [Embedded](https://github.com/frontegg/frontegg-ios-swift/tree/master/demo-embedded), [Application-Id](https://github.com/frontegg/frontegg-ios-swift/tree/master/demo-application-id), and [Multi-Region](https://github.com/frontegg/frontegg-ios-swift/tree/master/demo-multi-region) example projects to help you get started quickly
 
 For full documentation, visit the Frontegg Developer Portal:  

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,3 +4,4 @@
 - [API Reference](api.md)
 - [Usage Examples](usage.md)
 - [Advanced Topics](advanced.md)
+- [Offline Mode](offline-mode.md)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -450,68 +450,23 @@ This section documents all available configuration keys in `Frontegg.plist`.
 
 When `enableOfflineMode` is set to `true`, the SDK preserves the user's authenticated session when the device loses connectivity. This is critical for apps that must remain accessible without network (e.g., aviation, field service, industrial).
 
-#### How it works
+For the full integration guide, including:
 
-- On successful login, the SDK caches the user profile (`offlineUser`) and tokens in the keychain.
-- When the device goes offline, `isAuthenticated` remains `true` and `isOfflineMode` is set to `true`.
-- Token refresh is paused until connectivity returns. `getOrRefreshAccessTokenAsync()` returns the cached access token instead of attempting a network call.
-- When connectivity is restored, the SDK automatically refreshes tokens and resumes normal operation.
-- Logout only happens on explicit `logout()` call or a confirmed server rejection (HTTP 401).
+- custom unauthenticated offline UI wiring
+- authenticated offline fallback rules
+- logout and reconnect expectations
+- troubleshooting for sticky offline screens or blank transitions
+- the behavior changes between the previous baseline and the current SDK behavior
 
-#### Important: use `isAuthenticated` as the session source of truth
+see [Offline Mode and Custom Offline UI](offline-mode.md).
 
-Always gate your logged-in UI on `isAuthenticated`, **not** on `user != nil`. In offline scenarios, `isAuthenticated` may be `true` while `user` is `nil` (e.g., when the user's profile data was not cached before going offline). If you gate on `user != nil`, your app will incorrectly show the login screen to authenticated offline users.
+#### Quick rules
 
-#### Recommended UI routing pattern
-
-```swift
-struct MyApp: View {
-    @EnvironmentObject var fronteggAuth: FronteggAuth
-
-    var body: some View {
-        ZStack {
-            if fronteggAuth.isLoading {
-                LoaderView()
-            } else if fronteggAuth.isAuthenticated {
-                if fronteggAuth.user != nil {
-                    // Full experience — user data available
-                    UserPage()
-                } else {
-                    // Authenticated but user data unavailable (offline, no cached profile)
-                    // Show a degraded but functional UI
-                    OfflinePlaceholderView()
-                }
-            } else {
-                if fronteggAuth.isOfflineMode {
-                    // Not authenticated and no network — cannot log in
-                    NoConnectionPage()
-                } else {
-                    // Not authenticated, network available — show login
-                    LoginPage()
-                }
-            }
-        }
-    }
-}
-```
-
-#### Obtaining access tokens offline
-
-When offline, `getOrRefreshAccessTokenAsync()` returns the cached access token without attempting a network refresh. This allows your app to include the token in local operations or queue requests for when connectivity returns.
-
-```swift
-do {
-    let token = try await fronteggAuth.getOrRefreshAccessTokenAsync()
-    if let token = token {
-        // Use cached token — note: it may be expired, but no backend call can succeed offline anyway
-        headers["Authorization"] = "Bearer \(token)"
-    } else {
-        // No cached token available
-    }
-} catch {
-    // Only thrown for non-connectivity errors when online
-}
-```
+- Gate logged-in UI on `isAuthenticated`, not on `user != nil`.
+- Show your custom offline page only when `isAuthenticated == false && isOfflineMode == true`.
+- Keep authenticated users in the authenticated area even when `isOfflineMode == true`.
+- Wire the Retry action on your custom offline page to `fronteggAuth.recheckConnection()`.
+- When offline, `getOrRefreshAccessTokenAsync()` returns the cached access token if one is available.
 
 #### Offline restore on app restart
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -84,11 +84,12 @@ func fronteggSDK(didReceiveOAuthError context: FronteggOAuthErrorContext)
 | `refreshToken` | `ReadOnlyObservableValue<String?>` – The refresh token. `nil` if unauthorized. |
 | `user` | `ReadOnlyObservableValue<User?>` – Authenticated user info. `nil` if unauthorized. |
 | `isAuthenticated` | `ReadOnlyObservableValue<Bool>` – `true` if the user is logged in. |
-| `isLoading` | `ReadOnlyObservableValue<Bool>` – `true` while login or logout is in progress. |
-| `initializing` | `ReadOnlyObservableValue<Bool>` – `true` while SDK is initializing. |
-| `showLoader` | `ReadOnlyObservableValue<Bool>` – Indicates whether loading UI should be shown. |
+| `isLoading` | `ReadOnlyObservableValue<Bool>` – `true` while login, logout, or authenticated session transitions are in progress. |
+| `initializing` | `ReadOnlyObservableValue<Bool>` – `true` while the SDK is bootstrapping or restoring session state. |
+| `showLoader` | `ReadOnlyObservableValue<Bool>` – Indicates whether `FronteggWrapper` should keep showing loader UI. |
 | `refreshingToken` | `ReadOnlyObservableValue<Bool>` – Indicates whether a token refresh is ongoing. |
-| `isOfflineMode` | `ReadOnlyObservableValue<Bool>` – `true` when the device has no connectivity to Frontegg servers. |
+| `appLink` | `ReadOnlyObservableValue<Bool>` – Indicates that the SDK is in an app-link callback transition. |
+| `isOfflineMode` | `ReadOnlyObservableValue<Bool>` – `true` when the SDK has committed to offline mode for the current session state. When authenticated, the app should usually stay in the authenticated area. When unauthenticated and offline mode is enabled, the host app can route to a custom no-connection screen. |
 | `lastAttemptReason` | `AttemptReasonType?` – The reason for the last token refresh attempt result: `.noNetwork` (connectivity error) or `.unknown` (other error). `nil` after a successful refresh. |
 
 ## Configuration properties
@@ -117,10 +118,19 @@ Logs in the user. This will open the Frontegg login page in either an embedded w
 - `loginHint`: Optional. Pre-fills the login email.
 
 
-#### `logout(_ completion: @escaping (Result<Bool, FronteggError>) -> Void)`
+#### `logout(clearCookie: Bool = true, _ completion: FronteggAuth.LogoutHandler? = nil)`
 Logs the user out and clears session data.
 
-- `completion`: Called after logout completes.
+- `clearCookie`: Whether to remove matching hosted-session cookies from `WKHTTPCookieStore`.
+- `completion`: Called after logout finalization completes.
+
+When `enableOfflineMode` is `true`, the final unauthenticated screen depends on connectivity after logout:
+
+- if connectivity is available, the app should settle on the login screen
+- if the user logs out while offline, `isOfflineMode` may remain `true` so the app can render its custom unauthenticated offline screen
+
+#### `logout()`
+Convenience overload for `logout(clearCookie: true, ...)`.
 
 
 ### Account (tenant) management
@@ -143,7 +153,7 @@ Refreshes the access token if needed.
 #### `getOrRefreshAccessTokenAsync() async throws -> String?`
 Returns a valid access token for use in API calls. If the current token is near expiry, attempts to refresh it.
 
-When `enableOfflineMode` is `true` and the device is offline, returns the cached access token without attempting a network refresh. Returns `nil` if no cached token is available.
+When `enableOfflineMode` is `true` and the device is offline, returns the cached access token without attempting a network refresh. Returns `nil` if no cached token is available. The cached token may already be expired, which is expected while the app is offline.
 
 - **Returns**: A valid access token string, or `nil` if unavailable.
 - **Throws**: `FronteggError.authError(.failedToAuthenticate)` after exhausting retries (online only).
@@ -152,6 +162,11 @@ When `enableOfflineMode` is `true` and the device is offline, returns the cached
 Callback-based version of `getOrRefreshAccessTokenAsync()`.
 
 - `completion`: Called with `.success(token)` or `.failure(error)`.
+
+#### `recheckConnection()`
+Triggers a manual connectivity recovery attempt for custom offline UI flows.
+
+Call this from the Retry button on your app-owned offline screen. If network connectivity is back, the SDK will try to resume normal online operation.
 
 
 ### Passkeys authentication

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,0 +1,378 @@
+# Offline Mode and Custom Offline UI
+
+This guide explains how to integrate `enableOfflineMode` with an app-owned offline screen and how to validate the expected behavior in offline, reconnect, and logout scenarios.
+
+Use this page when validating an integration such as SkyPath's:
+
+- custom unauthenticated offline UI
+- authenticated offline behavior
+- reconnect and token recovery
+- logout behavior while online or offline
+- differences between the previous baseline behavior and the current behavior
+
+## What Did Not Change
+
+There is no breaking public API change in offline-mode UI wiring between the previous baseline and the current SDK behavior.
+
+The host app still uses the same public contract:
+
+- `enableOfflineMode`
+- `isAuthenticated`
+- `isOfflineMode`
+- `isLoading`
+- `initializing`
+- `showLoader`
+- `appLink`
+- `recheckConnection()`
+
+No new host-app callback, delegate, plist key, or offline-screen API was added for this flow.
+
+## Required Configuration
+
+Enable offline mode in `Frontegg.plist`:
+
+```xml
+<key>enableOfflineMode</key>
+<true/>
+<key>networkMonitoringInterval</key>
+<real>10</real>
+```
+
+Your root content should still be mounted inside `FronteggWrapper`, because the wrapper owns SDK bootstrap and app-link loader states.
+
+```swift
+@main
+struct ExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            FronteggWrapper {
+                RootView()
+            }
+        }
+    }
+}
+```
+
+## Required Routing Contract
+
+Treat the SDK state as the source of truth for routing. Do not mix it with a separate app-level reachability state when deciding which authentication screen to show.
+
+### Root routing matrix
+
+| SDK state | Expected UI |
+|----------|-------------|
+| `initializing == true`, `showLoader == true`, or `appLink == true` | `FronteggWrapper` loader |
+| `isLoading == true` | App loader |
+| `isAuthenticated == true` and `user != nil` | Normal authenticated app UI |
+| `isAuthenticated == true` and `user == nil` | Authenticated offline fallback UI, not login |
+| `isAuthenticated == false` and `isOfflineMode == true` | App-owned custom offline UI |
+| `isAuthenticated == false` and `isOfflineMode == false` | Login UI |
+
+### Quick interpretation
+
+- `isAuthenticated == true` means the user is still considered logged in.
+- `user` may be `nil` or non-`nil` while offline.
+- `isOfflineMode == true` does not automatically mean "show the offline login screen".
+- The custom unauthenticated offline page is only for `isAuthenticated == false && isOfflineMode == true`.
+
+### Reference SwiftUI implementation
+
+```swift
+struct RootView: View {
+    @EnvironmentObject var fronteggAuth: FronteggAuth
+
+    var body: some View {
+        if fronteggAuth.isLoading {
+            LoaderView()
+        } else if fronteggAuth.isAuthenticated {
+            if let _ = fronteggAuth.user {
+                UserPage()
+            } else {
+                AuthenticatedOfflineView()
+            }
+        } else if fronteggAuth.isOfflineMode {
+            NoConnectionPage()
+        } else {
+            LoginPage()
+        }
+    }
+}
+
+struct NoConnectionPage: View {
+    @EnvironmentObject private var fronteggAuth: FronteggAuth
+
+    var body: some View {
+        VStack {
+            Text("No Connection")
+            Button("Retry") {
+                fronteggAuth.recheckConnection()
+            }
+        }
+    }
+}
+```
+
+## Offline UI Examples
+
+These examples are the easiest way to validate whether the app is wired correctly.
+
+### Example 1: Authenticated offline with cached user
+
+State:
+
+- `isAuthenticated == true`
+- `isOfflineMode == true`
+- `user != nil`
+
+Expected UI:
+
+- stay inside the app
+- show the normal authenticated screen
+- optionally show an offline banner or badge
+
+```swift
+if fronteggAuth.isAuthenticated, fronteggAuth.isOfflineMode, fronteggAuth.user != nil {
+    UserPage()
+}
+```
+
+### Example 2: Authenticated offline without cached user
+
+State:
+
+- `isAuthenticated == true`
+- `isOfflineMode == true`
+- `user == nil`
+
+Expected UI:
+
+- stay inside the app
+- do not show login
+- do not show the unauthenticated offline page
+- show an authenticated offline fallback view
+
+```swift
+if fronteggAuth.isAuthenticated, fronteggAuth.user == nil {
+    AuthenticatedOfflineView()
+}
+```
+
+```swift
+struct AuthenticatedOfflineView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Authenticated Offline")
+                .font(.headline)
+            Text("User details will load when connectivity returns.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+    }
+}
+```
+
+### Example 3: Unauthenticated offline
+
+State:
+
+- `isAuthenticated == false`
+- `isOfflineMode == true`
+
+Expected UI:
+
+- show the app-owned custom offline page
+- do not show the login page
+
+```swift
+if !fronteggAuth.isAuthenticated && fronteggAuth.isOfflineMode {
+    NoConnectionPage()
+}
+```
+
+### Example 4: Retry button on the custom offline page
+
+```swift
+struct NoConnectionPage: View {
+    @EnvironmentObject private var fronteggAuth: FronteggAuth
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("No Connection")
+            Button("Retry") {
+                fronteggAuth.recheckConnection()
+            }
+        }
+    }
+}
+```
+
+### Critical rules
+
+- Gate session UI on `isAuthenticated`, not on `user != nil`.
+- Show the custom unauthenticated offline page only when `isAuthenticated == false && isOfflineMode == true`.
+- Keep authenticated users inside the authenticated area even when `isOfflineMode == true`.
+- Allow both `user == nil` and `user != nil` inside authenticated offline mode.
+- Keep the retry button wired to `recheckConnection()`.
+- Do not drive login-vs-offline routing from a separate reachability library unless it is strictly diagnostic.
+
+## Expected Offline Behavior
+
+### Cold launch with no session
+
+When `enableOfflineMode == true` and no user session exists:
+
+- online startup should settle on the login screen
+- offline startup should settle on the custom unauthenticated offline screen
+- transient probe failures should not permanently blink or stick the offline screen
+
+When `enableOfflineMode == false`:
+
+- the app should go straight to login
+- custom offline UI should not appear
+
+### Authenticated connectivity loss
+
+When the user is already authenticated and connectivity is lost:
+
+- `isAuthenticated` remains `true`
+- `isOfflineMode` becomes `true`
+- the app should keep the user in the authenticated area
+- `getOrRefreshAccessTokenAsync()` returns the cached access token if one exists
+- the cached access token may already be expired, which is expected while offline
+
+If the user profile was not cached before connectivity was lost, `user` may be `nil` while `isAuthenticated` is still `true`. That is why authenticated routing must not depend only on `user != nil`.
+
+### Reconnect
+
+When connectivity returns:
+
+- the SDK attempts to refresh tokens and restore normal online state
+- `isOfflineMode` should clear after recovery
+- the authenticated user should remain in the app if the session is still valid
+
+### Logout
+
+When offline mode is enabled:
+
+- online logout should settle on the login screen
+- logout while already offline should settle on the app-owned unauthenticated offline screen
+- reconnect after offline logout should return the user to the login screen without requiring an app restart
+
+The host app should never need to restart to escape a stale offline screen.
+
+## Cached Artifact Restore Rules
+
+When the app restarts without connectivity, the SDK restores as much authenticated state as the cached artifacts allow:
+
+| Cached artifacts | Expected restore |
+|------------------|------------------|
+| Access token + refresh token | Authenticated offline |
+| Access token only | Authenticated offline, no refresh capability until reconnect |
+| Refresh token + cached user profile | Authenticated offline, can refresh when reconnect happens |
+| Refresh token only, no cached user profile | Unauthenticated offline, artifacts preserved for reconnect |
+| No tokens | Unauthenticated |
+
+## Common Integration Mistakes
+
+These are the most common causes of wrong offline UI behavior in host apps:
+
+- Showing login whenever `user == nil`, even if `isAuthenticated == true`
+- Showing the custom offline page whenever `isOfflineMode == true`, even if the user is still authenticated
+- Driving routing from a second reachability flag instead of the SDK state
+- Rendering the hosted login web UI underneath the custom offline page instead of switching root branches
+- Leaving a gap in the root router where no loader, login, offline page, or authenticated page is rendered
+- Treating a transient logout or reconnect transition as a final state
+
+## Troubleshooting Customer Symptoms
+
+### Logging out while offline shows the default hosted Frontegg offline screen
+
+Check:
+
+- `enableOfflineMode == true`
+- the app switches to the custom offline page when `isAuthenticated == false && isOfflineMode == true`
+- the custom offline page lives in app code, outside the hosted login web UI
+
+Expected current behavior:
+
+- after offline logout, the SDK should preserve unauthenticated offline mode and the app should render its custom offline page
+
+### The custom offline screen appears during an online logout and stays until restart
+
+Check:
+
+- the app is not using its own reachability state to force the offline page
+- the app routes only from SDK auth state
+- the login screen branch is available immediately when `isAuthenticated == false && isOfflineMode == false`
+
+Expected current behavior:
+
+- online logout should settle on login, not a sticky offline screen
+
+### Toggling airplane mode during logout causes a blank screen that never recovers
+
+Check:
+
+- the root router always has an exhaustive branch for loader, authenticated, unauthenticated offline, or login
+- the app does not temporarily hide all content while waiting for a custom reachability callback
+- the app still renders through `FronteggWrapper`
+
+Expected current behavior:
+
+- logout should settle either to login or to the custom offline page, and reconnect should not require an app restart
+
+### Diagnostic values to capture if the issue still reproduces
+
+If a customer still sees a wrong screen, capture the runtime values of:
+
+- `isAuthenticated`
+- `isOfflineMode`
+- `isLoading`
+- `initializing`
+- `showLoader`
+- `appLink`
+- whether `user` is `nil`
+
+These values are enough to determine whether the issue is in SDK state finalization or in app routing.
+
+## Previous Behavior vs Current Behavior
+
+This section summarizes behavior changes that matter for custom offline UI integrations.
+
+| Area | Earlier behavior | Current behavior | App impact |
+|------|-------------------|----------------------|------------|
+| Public offline UI contract | Existing contract based on `isAuthenticated`, `isOfflineMode`, and `recheckConnection()` | Same public contract | No host-app API migration required |
+| Unauthenticated cold launch | More vulnerable to transient connectivity probe failures committing offline UI too early | Performs a short connectivity settlement flow before committing unauthenticated offline mode | Fewer false custom offline-screen flashes |
+| Reconnect handling | Stale debounced disconnect work could still win after connectivity recovered | Pending offline debounce is canceled and stale callbacks are ignored | Less risk of `isOfflineMode` flipping back to `true` after recovery |
+| Successful login or refresh | Old transient offline state could linger after authenticated success | Authenticated success clears stale offline debounce and monitoring state | Less risk of carrying offline UI state into a healthy authenticated session |
+| Logout while offline | Session cleanup could finish without intentionally preserving the unauthenticated offline state | Logout explicitly preserves unauthenticated offline mode when the user was already offline | Custom offline page should now appear directly after offline logout |
+| Logout while online | More vulnerable to stale monitoring or probe work affecting the final unauthenticated screen | Logout owns connectivity teardown and re-settles the unauthenticated end state | Less risk of sticky custom offline UI during online logout |
+| Demo app changes | No dedicated screen markers | Added accessibility markers and sticky diagnostics | Test-only; no product integration change required |
+
+## Validated Scenarios
+
+The current SDK behavior is exercised against these demo-embedded scenarios:
+
+| Scenario | Expected result |
+|----------|-----------------|
+| Cold launch through transient probe failures | Login appears and the custom offline screen does not blink persistently |
+| Authenticated relaunch with network path unavailable | User remains authenticated and enters authenticated offline mode |
+| Authenticated offline mode recovery | Reconnect clears offline mode and refreshes tokens |
+| Logout while authenticated offline | App lands on the custom unauthenticated offline page |
+| Offline mode disabled | Offline indicators and custom offline UI do not appear |
+
+## Validation Checklist for App Teams
+
+Use this checklist when comparing your app against the expected integration:
+
+1. `enableOfflineMode` is enabled in `Frontegg.plist`.
+2. The root app content is mounted inside `FronteggWrapper`.
+3. The root router follows the state matrix in this guide.
+4. The custom offline page renders only for `isAuthenticated == false && isOfflineMode == true`.
+5. Authenticated offline users stay in the authenticated area, even if `user == nil`.
+6. The retry button calls `fronteggAuth.recheckConnection()`.
+7. No second reachability state overrides the SDK when choosing login vs offline UI.
+8. The app never renders an empty root state during logout or reconnect.
+
+If all eight checks are true and the issue still reproduces, capture the diagnostic values listed above together with the reproduction steps.

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -2,7 +2,7 @@
 
 This guide explains how to integrate `enableOfflineMode` with an app-owned offline screen and how to validate the expected behavior in offline, reconnect, and logout scenarios.
 
-Use this page when validating an integration such as SkyPath's:
+Use this page when validating a host-app integration with:
 
 - custom unauthenticated offline UI
 - authenticated offline behavior


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication/session lifecycle (logout, token refresh, OAuth callback routing) and network monitoring concurrency; regressions could strand users in offline/unauthenticated states or break social/OIDC login redirects.
> 
> **Overview**
> **Improves offline-mode correctness and race-safety** by introducing generation-based invalidation for connectivity callbacks, centralizing monitor/debounce cleanup, and adding explicit logout transition ownership (prevents stale offline transitions during logout/token changes and adds better unauthenticated-offline recovery via `recheckConnection`).
> 
> **Hardens OAuth/social login flows** by normalizing redirect-uri generation to support base-path and root callback aliases, canonicalizing social `state`, tracking/clearing pending social PKCE verifiers, adding a watchdog to recover from stalled `/oauth/account/social/success` pages, and ensuring queued OAuth-error presentation uses captured runtime settings/delegate.
> 
> **CI stability tweaks**: adds a SwiftPM artifact-cache reset step to macOS workflows and disables Xcode parallel testing for unit/E2E runs; expands unit/E2E test coverage for the new redirect/offline behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884a7888e051446774dec494953dfadeacb8a399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->