### PR TITLE
fix: blank screen when network lost during logout

### DIFF
--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -79,13 +79,14 @@ extension FronteggAuth {
         self.setIsOfflineMode(false)
 
         // If the user is unauthenticated (e.g. logged out while offline),
-        // clear offline state and reload the login page instead of refreshing tokens.
+        // clear offline state so the host app can show its login UI.
+        // Mirrors the unauthenticated path in recheckConnection().
         let hasRuntimeSession = self.isAuthenticated
             || self.accessToken != nil
             || self.refreshToken != nil
 
         if !hasRuntimeSession {
-            self.logger.info("Network reconnected in unauthenticated state — reloading login page")
+            self.logger.info("Network reconnected in unauthenticated state — clearing offline state")
             self.invalidateConnectivityObservers()
             self.stopOfflineMonitoring()
             self.lastAttemptReason = nil
@@ -97,7 +98,6 @@ extension FronteggAuth {
                 self.setShowLoader(false)
                 self.setAppLink(false)
                 self.setExternalLink(false)
-                self.webview?.reloadFreshLoginPage()
             }
             return
         }

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -78,6 +78,30 @@ extension FronteggAuth {
         self.logger.info("Connected to the internet")
         self.setIsOfflineMode(false)
 
+        // If the user is unauthenticated (e.g. logged out while offline),
+        // clear offline state and reload the login page instead of refreshing tokens.
+        let hasRuntimeSession = self.isAuthenticated
+            || self.accessToken != nil
+            || self.refreshToken != nil
+
+        if !hasRuntimeSession {
+            self.logger.info("Network reconnected in unauthenticated state — reloading login page")
+            self.invalidateConnectivityObservers()
+            self.stopOfflineMonitoring()
+            self.lastAttemptReason = nil
+            DispatchQueue.main.async {
+                self.setUser(nil)
+                self.setIsLoading(false)
+                self.setWebLoading(false)
+                self.setInitializing(false)
+                self.setShowLoader(false)
+                self.setAppLink(false)
+                self.setExternalLink(false)
+                self.webview?.reloadFreshLoginPage()
+            }
+            return
+        }
+
         // Keep monitoring active — don't stop it here.
         // If refreshTokenIfNeeded() succeeds, $accessToken subscription stops monitoring.
         // If it fails, monitoring stays active to detect the next reconnection.

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -44,7 +44,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         return currentFlow == .login ? fallback : currentFlow
     }
 
-    private func reloadFreshLoginPage(after delay: TimeInterval = 0) {
+    func reloadFreshLoginPage(after delay: TimeInterval = 0) {
         cancelSocialSuccessWatchdog()
         let (loginUrl, codeVerifier) = AuthorizeUrlGenerator().generate(remainCodeVerifier: true)
         CredentialManager.saveCodeVerifier(codeVerifier)

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -44,7 +44,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         return currentFlow == .login ? fallback : currentFlow
     }
 
-    func reloadFreshLoginPage(after delay: TimeInterval = 0) {
+    private func reloadFreshLoginPage(after delay: TimeInterval = 0) {
         cancelSocialSuccessWatchdog()
         let (loginUrl, codeVerifier) = AuthorizeUrlGenerator().generate(remainCodeVerifier: true)
         CredentialManager.saveCodeVerifier(codeVerifier)


### PR DESCRIPTION
## Summary
- When a user logs out while offline (or network drops during logout), `reconnectedToInternet()` only ran the authenticated path (`refreshTokenIfNeeded`), which is a no-op without tokens — leaving a blank screen
- Added unauthenticated handling: detects no-session state and clears offline flags + reloads the login page via `reloadFreshLoginPage()`
- Mirrors the existing `recheckConnection()` logic for the automatic reconnection callback

Fixes FR-24387

## Test plan
- [ ] Run existing test suite (629 tests pass, 0 failures)
- [ ] Manual: log in → log out → turn off network → turn on network → verify login page loads (no blank screen)
- [ ] Verify authenticated offline → online path still works correctly
