### PR TITLE
fix(auth): close refresh-token rotation race (TKT-36495)

### DIFF
--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -61,6 +61,10 @@ public class FronteggAuth: FronteggState {
     var offlineDebounceWork: DispatchWorkItem?
     let connectivityGenerationLock = NSLock()
     var connectivityGeneration: UInt64 = 0
+    /// Serializes concurrent refresh callers so only one rotation hits the
+    /// server at a time; subsequent callers await the same Task.
+    let refreshSerializationLock = NSLock()
+    var inflightRefreshTask: Task<Bool, Never>?
     let logoutTransitionLock = NSLock()
     var logoutInProgress = false
     // internal for extension access (FronteggAuth+Connectivity.swift)

--- a/Sources/FronteggSwift/auth/FronteggAuth+Refresh.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Refresh.swift
@@ -5,6 +5,48 @@
 
 import Foundation
 import Dispatch
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+#endif
+
+/// Background-task handle that keeps iOS from suspending the app mid-refresh.
+/// `end()` is idempotent across the expiration handler and the caller's defer.
+#if canImport(UIKit) && !os(watchOS)
+fileprivate final class RefreshBackgroundTaskHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taskId: UIBackgroundTaskIdentifier = .invalid
+
+    @MainActor
+    func begin(name: String) {
+        lock.lock()
+        let current = taskId
+        lock.unlock()
+        guard current == .invalid else { return }
+
+        let newId = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+            self?.end()
+        }
+        lock.lock()
+        taskId = newId
+        lock.unlock()
+    }
+
+    func end() {
+        lock.lock()
+        let captured = taskId
+        taskId = .invalid
+        lock.unlock()
+        guard captured != .invalid else { return }
+        if Thread.isMainThread {
+            UIApplication.shared.endBackgroundTask(captured)
+        } else {
+            DispatchQueue.main.async {
+                UIApplication.shared.endBackgroundTask(captured)
+            }
+        }
+    }
+}
+#endif
 
 extension FronteggAuth {
     func isAutoRefreshBlocked(source: RefreshInvocationSource) -> Bool {
@@ -180,6 +222,40 @@ extension FronteggAuth {
         refreshTokenDispatch = nil
     }
 
+    /// Writes rotated tokens to the keychain before post-refresh work runs so a
+    /// mid-flow suspend/kill cannot leave the keychain holding the invalidated
+    /// token. Non-throwing: `setCredentialsInternal` saves again on the happy path.
+    internal func persistRotatedTokensImmediately(
+        accessToken: String,
+        refreshToken: String,
+        tenantId: String?,
+        enableSessionPerTenant: Bool
+    ) {
+        do {
+            if enableSessionPerTenant, let tenantId = tenantId {
+                try self.credentialManager.saveTokenForTenant(refreshToken, tenantId: tenantId, tokenType: .refreshToken)
+                try self.credentialManager.saveTokenForTenant(accessToken, tenantId: tenantId, tokenType: .accessToken)
+                self.logger.info("Persisted rotated tokens to keychain (tenant: \(tenantId)) immediately after refresh")
+            } else {
+                try self.credentialManager.save(key: KeychainKeys.refreshToken.rawValue, value: refreshToken)
+                try self.credentialManager.save(key: KeychainKeys.accessToken.rawValue, value: accessToken)
+                self.logger.info("Persisted rotated tokens to keychain (global) immediately after refresh")
+            }
+        } catch {
+            self.logger.error("Failed to persist rotated tokens to keychain immediately after refresh: \(error)")
+            SentryHelper.logError(error, context: [
+                "auth": [
+                    "method": "persistRotatedTokensImmediately",
+                    "enableSessionPerTenant": enableSessionPerTenant,
+                    "hasTenantId": tenantId != nil
+                ],
+                "error": [
+                    "type": "immediate_rotation_persistence_failed"
+                ]
+            ])
+        }
+    }
+
     public func refreshTokenIfNeeded(attempts: Int = 0, skipNetworkCheck: Bool = false) async -> Bool {
         await refreshTokenIfNeededInternal(
             source: .manualUser,
@@ -188,7 +264,48 @@ extension FronteggAuth {
         )
     }
 
+    /// Must be called while holding `refreshSerializationLock`.
+    private func claimOrStartRefreshTaskLocked(
+        source: RefreshInvocationSource,
+        attempts: Int,
+        skipNetworkCheck: Bool
+    ) -> Task<Bool, Never> {
+        if let existing = inflightRefreshTask {
+            return existing
+        }
+        let task = Task<Bool, Never> { [weak self] in
+            guard let self = self else { return false }
+            let result = await self.performRefreshTokenFlow(
+                source: source,
+                attempts: attempts,
+                skipNetworkCheck: skipNetworkCheck
+            )
+            self.refreshSerializationLock.withLock {
+                self.inflightRefreshTask = nil
+            }
+            return result
+        }
+        inflightRefreshTask = task
+        return task
+    }
+
     internal func refreshTokenIfNeededInternal(
+        source: RefreshInvocationSource,
+        attempts: Int = 0,
+        skipNetworkCheck: Bool = false
+    ) async -> Bool {
+        let task: Task<Bool, Never> = refreshSerializationLock.withLock {
+            claimOrStartRefreshTaskLocked(
+                source: source,
+                attempts: attempts,
+                skipNetworkCheck: skipNetworkCheck
+            )
+        }
+        return await task.value
+    }
+
+    /// Body of the serialized refresh; only one instance runs at a time.
+    internal func performRefreshTokenFlow(
         source: RefreshInvocationSource,
         attempts: Int = 0,
         skipNetworkCheck: Bool = false
@@ -356,6 +473,16 @@ extension FronteggAuth {
         setRefreshingToken(true)
         defer { setRefreshingToken(false) }
 
+        // Keep the app awake for the full rotation window so iOS cannot suspend
+        // us between the server rotating the token and the keychain write.
+#if canImport(UIKit) && !os(watchOS)
+        let bgTaskHandle = RefreshBackgroundTaskHandle()
+        await MainActor.run {
+            bgTaskHandle.begin(name: "FronteggRefreshToken")
+        }
+        defer { bgTaskHandle.end() }
+#endif
+
         let preservedTenantId = enableSessionPerTenant ? credentialManager.getLastActiveTenantId() : nil
 
         // Log token refresh attempt details
@@ -460,6 +587,18 @@ extension FronteggAuth {
                 }
             }
 
+            // Persist rotated tokens before setCredentialsInternal so a /me
+            // hang or mid-flow kill cannot strand the new refresh token.
+            let tenantIdForImmediatePersistence: String? = enableSessionPerTenant
+                ? (currentTenantId ?? preservedTenantId ?? credentialManager.getLastActiveTenantId())
+                : nil
+            persistRotatedTokensImmediately(
+                accessToken: data.access_token,
+                refreshToken: data.refresh_token,
+                tenantId: tenantIdForImmediatePersistence,
+                enableSessionPerTenant: enableSessionPerTenant
+            )
+
             await self.setCredentialsInternal(
                 accessToken: data.access_token,
                 refreshToken: data.refresh_token,
@@ -496,6 +635,26 @@ extension FronteggAuth {
 
         } catch let error as FronteggError {
             if case .authError(FronteggError.Authentication.failedToRefreshToken(let message)) = error {
+                // If the in-memory refresh token was rotated by another path
+                // while our request was in flight, the 401 is stale — don't
+                // wipe credentials.
+                let currentInMemoryRefreshToken = await MainActor.run { self.refreshToken }
+                if let current = currentInMemoryRefreshToken, current != refreshToken {
+                    self.logger.warning("Refresh failed but in-memory refresh token has already been rotated; skipping credential wipe")
+                    SentryHelper.addBreadcrumb(
+                        "Refresh token rotation race detected; skipping logout",
+                        category: "auth",
+                        level: .warning,
+                        data: [
+                            "sentRefreshTokenLength": refreshToken.count,
+                            "currentRefreshTokenLength": current.count,
+                            "attempts": attempts,
+                            "enableSessionPerTenant": enableSessionPerTenant
+                        ]
+                    )
+                    return false
+                }
+
                 let tenantIdToPreserve: String? = enableSessionPerTenant
                     ? (preservedTenantId ?? credentialManager.getLastActiveTenantId())
                     : nil

--- a/Sources/FronteggSwift/auth/FronteggAuth+Refresh.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Refresh.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Dispatch
+import CryptoKit
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
 #endif
@@ -60,7 +61,9 @@ extension FronteggAuth {
         let remainingTime = (Double(expirationTime) * 1000) - now
 
         let minRefreshWindow: Double = 20000 // Minimum 20 seconds before expiration, in milliseconds
-        let adaptiveRefreshTime = remainingTime * 0.8 // 80% of remaining time
+        // Refresh at 50% of remaining TTL so each rotation lands with comfortable
+        // network/retry headroom instead of near expiry.
+        let adaptiveRefreshTime = remainingTime * 0.5
 
         return remainingTime > minRefreshWindow ? adaptiveRefreshTime / 1000 : max((remainingTime - minRefreshWindow) / 1000, 0)
     }
@@ -220,6 +223,58 @@ extension FronteggAuth {
         logger.info("Canceling previous refresh token task")
         refreshTokenDispatch?.cancel()
         refreshTokenDispatch = nil
+    }
+
+    /// Truncated hex of SHA-256 of the refresh token — used as a keychain
+    /// tombstone value. Short enough to stay out of logs, long enough to
+    /// uniquely identify a given token across process restarts.
+    internal func refreshTokenFingerprint(_ token: String) -> String {
+        let digest = SHA256.hash(data: Data(token.utf8))
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Marks a refresh as in-flight so a force-kill or crash before the response
+    /// leaves a detectable breadcrumb for the next launch.
+    internal func writeRefreshInFlightTombstone(for refreshToken: String) {
+        let fingerprint = refreshTokenFingerprint(refreshToken)
+        do {
+            try credentialManager.save(key: KeychainKeys.refreshInFlight.rawValue, value: fingerprint)
+        } catch {
+            self.logger.warning("Failed to write refresh-in-flight tombstone: \(error)")
+        }
+    }
+
+    internal func clearRefreshInFlightTombstone() {
+        credentialManager.delete(key: KeychainKeys.refreshInFlight.rawValue)
+    }
+
+    /// True iff a tombstone exists and matches the given refresh token —
+    /// i.e. the previous process died with a refresh request on the wire for
+    /// this exact token.
+    internal func hasOrphanedRefreshTombstone(matching refreshToken: String?) -> Bool {
+        guard
+            let refreshToken,
+            let stored = try? credentialManager.get(key: KeychainKeys.refreshInFlight.rawValue)
+        else {
+            return false
+        }
+        return stored == refreshTokenFingerprint(refreshToken)
+    }
+
+    /// Called once per app start. Emits a Sentry breadcrumb when the previous
+    /// session died mid-refresh so residual rotation-orphan rate is observable
+    /// even after this PR's client-side hardening.
+    internal func detectAndReportOrphanedRefreshAtStartup(refreshToken: String?) {
+        guard hasOrphanedRefreshTombstone(matching: refreshToken) else { return }
+        self.logger.warning("Startup: detected orphaned refresh tombstone — previous session died mid-refresh")
+        SentryHelper.addBreadcrumb(
+            "Startup detected orphaned refresh (previous process interrupted mid-rotation)",
+            category: "auth",
+            level: .warning,
+            data: [
+                "hasRefreshToken": refreshToken != nil
+            ]
+        )
     }
 
     /// Writes rotated tokens to the keychain before post-refresh work runs so a
@@ -484,6 +539,12 @@ extension FronteggAuth {
 #endif
 
         let preservedTenantId = enableSessionPerTenant ? credentialManager.getLastActiveTenantId() : nil
+        let hadOrphanedTombstoneOnEntry = hasOrphanedRefreshTombstone(matching: refreshToken)
+
+        // Record that a refresh is on the wire. If the process is killed before
+        // the response lands, this tombstone survives and the next launch can
+        // attribute the resulting 401 to an interrupted rotation.
+        writeRefreshInFlightTombstone(for: refreshToken)
 
         // Log token refresh attempt details
         SentryHelper.addBreadcrumb(
@@ -496,7 +557,8 @@ extension FronteggAuth {
                 "preservedTenantId": preservedTenantId ?? "nil",
                 "hasRefreshToken": true,
                 "refreshTokenLength": refreshToken.count,
-                "hasAccessToken": accessToken != nil
+                "hasAccessToken": accessToken != nil,
+                "followsInterruptedRefresh": hadOrphanedTombstoneOnEntry
             ]
         )
 
@@ -598,6 +660,9 @@ extension FronteggAuth {
                 tenantId: tenantIdForImmediatePersistence,
                 enableSessionPerTenant: enableSessionPerTenant
             )
+            // Rotation completed and the new token is durable; tombstone no
+            // longer indicates an unresolved in-flight request.
+            clearRefreshInFlightTombstone()
 
             await self.setCredentialsInternal(
                 accessToken: data.access_token,
@@ -652,6 +717,9 @@ extension FronteggAuth {
                             "enableSessionPerTenant": enableSessionPerTenant
                         ]
                     )
+                    // The other path completed rotation; our tombstone no
+                    // longer points at a live in-flight request.
+                    clearRefreshInFlightTombstone()
                     return false
                 }
 
@@ -668,7 +736,11 @@ extension FronteggAuth {
                         "method": "refreshTokenIfNeeded",
                         "attempts": attempts,
                         "enableSessionPerTenant": enableSessionPerTenant,
-                        "hasPreservedTenantId": enableSessionPerTenant && preservedTenantId != nil
+                        "hasPreservedTenantId": enableSessionPerTenant && preservedTenantId != nil,
+                        // Surfaces the residual rotation-orphan rate: true means
+                        // this 401 followed a refresh that was interrupted
+                        // before the previous process could persist RT_NEW.
+                        "followsInterruptedRefresh": hadOrphanedTombstoneOnEntry
                     ],
                     "error": [
                         "type": "failed_to_refresh_token",
@@ -689,6 +761,7 @@ extension FronteggAuth {
                     context: context
                 )
 
+                clearRefreshInFlightTombstone()
                 if enableSessionPerTenant {
                     self.credentialManager.clear(excludingKeys: [KeychainKeys.lastActiveTenantId.rawValue])
                 } else {

--- a/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift
@@ -250,6 +250,11 @@ extension FronteggAuth {
             accessToken = try? credentialManager.get(key: KeychainKeys.accessToken.rawValue)
         }
         
+        // If the previous process died with a refresh in flight, the tombstone
+        // survived. Emit a breadcrumb so residual rotation-orphan rate stays
+        // measurable after the client-side hardening.
+        detectAndReportOrphanedRefreshAtStartup(refreshToken: refreshToken)
+
         // Explicit state categories for startup restore
         let hasAnySessionArtifacts = (refreshToken != nil || accessToken != nil)
         let canRestoreOfflineAuthenticatedState = (accessToken != nil) ||

--- a/Sources/FronteggSwift/models/plist/FronteggPlist.swift
+++ b/Sources/FronteggSwift/models/plist/FronteggPlist.swift
@@ -39,6 +39,8 @@ struct FronteggPlist: Decodable, Equatable {
     let entitlementsEnabled: Bool
     let dismissAuthSessionOnOffline: Bool
     let offlineDebounceDelay: TimeInterval
+    /// HTTP timeout (seconds) for the refresh-token request.
+    let refreshTokenTimeout: TimeInterval
 
     enum CodingKeys: CodingKey {
         case keychainService
@@ -67,6 +69,7 @@ struct FronteggPlist: Decodable, Equatable {
         case entitlementsEnabled
         case dismissAuthSessionOnOffline
         case offlineDebounceDelay
+        case refreshTokenTimeout
     }
 
     init(
@@ -96,7 +99,8 @@ struct FronteggPlist: Decodable, Equatable {
         loginOrganizationAlias: String? = nil,
         entitlementsEnabled: Bool = false,
         dismissAuthSessionOnOffline: Bool = false,
-        offlineDebounceDelay: TimeInterval = 2.0
+        offlineDebounceDelay: TimeInterval = 2.0,
+        refreshTokenTimeout: TimeInterval = 20
     ) {
         self.keychainService = keychainService
         self.embeddedMode = embeddedMode
@@ -125,6 +129,7 @@ struct FronteggPlist: Decodable, Equatable {
         self.entitlementsEnabled = entitlementsEnabled
         self.dismissAuthSessionOnOffline = dismissAuthSessionOnOffline
         self.offlineDebounceDelay = offlineDebounceDelay
+        self.refreshTokenTimeout = refreshTokenTimeout
     }
 
     init(from decoder: any Decoder) throws {
@@ -207,6 +212,9 @@ struct FronteggPlist: Decodable, Equatable {
 
         let offlineDebounceDelay = try container.decodeIfPresent(TimeInterval.self, forKey: .offlineDebounceDelay)
         self.offlineDebounceDelay = offlineDebounceDelay ?? 2.0
+
+        let refreshTokenTimeout = try container.decodeIfPresent(TimeInterval.self, forKey: .refreshTokenTimeout)
+        self.refreshTokenTimeout = max(refreshTokenTimeout ?? 20, 10)
 
         do {
             self.payload = try Payload(from: decoder)

--- a/Sources/FronteggSwift/services/Api.swift
+++ b/Sources/FronteggSwift/services/Api.swift
@@ -563,29 +563,35 @@ public class Api {
         return try JSONDecoder().decode(AuthResponse.self, from: data)
     }
     
+    internal func resolveRefreshTokenTimeout() -> Int {
+        let configured = (try? PlistHelper.fronteggConfig())?.refreshTokenTimeout ?? 20
+        return max(Int(configured), 10)
+    }
+
     internal func refreshToken(refreshToken: String, tenantId: String? = nil, accessToken: String? = nil) async throws -> AuthResponse {
+        let refreshHttpTimeout = resolveRefreshTokenTimeout()
         // If tenantId is provided, use the new refresh endpoint that supports per-tenant sessions
         if let unwrappedTenantId = tenantId {
-            self.logger.info("Refreshing token with tenantId: \(unwrappedTenantId) (refresh token length: \(refreshToken.count))")
+            self.logger.info("Refreshing token with tenantId: \(unwrappedTenantId) (refresh token length: \(refreshToken.count), timeout: \(refreshHttpTimeout)s)")
             let refreshTokenCookie = "\(self.cookieName)=\(refreshToken)"
-            
+
             var headers: [String: String] = [
                 "Cookie": refreshTokenCookie,
                 "frontegg-vendor-host": self.baseUrl
             ]
-            
+
             // Include access token in Authorization header if provided
             // This is needed for tenant-specific refresh to work correctly
             if let accessToken = accessToken {
                 headers["Authorization"] = "Bearer \(accessToken)"
                 self.logger.info("Including access token in Authorization header for tenant-specific refresh")
             }
-            
+
             let (data, response) = try await postRequest(
                 path: "identity/resources/auth/v1/user/token/refresh",
                 body: ["tenantId": unwrappedTenantId],
                 additionalHeaders: headers,
-                timeout: 5
+                timeout: refreshHttpTimeout
             )
             
             if let res = response as? HTTPURLResponse {
@@ -672,10 +678,11 @@ public class Api {
                 throw error
             }
         } else {
+            self.logger.info("Refreshing token via oauth/token (timeout: \(refreshHttpTimeout)s)")
             let (data, response) = try await postRequest(path: "oauth/token", body: [
                 "grant_type": "refresh_token",
                 "refresh_token": refreshToken,
-            ], timeout: 5)
+            ], timeout: refreshHttpTimeout)
             
             if let res = response as? HTTPURLResponse {
                 if res.statusCode == 401 {

--- a/Sources/FronteggSwift/services/CredentialManager.swift
+++ b/Sources/FronteggSwift/services/CredentialManager.swift
@@ -14,6 +14,10 @@ public enum KeychainKeys: String {
     case region = "fe_region"
     case userInfo = "user_me"
     case lastActiveTenantId = "fe_lastActiveTenantId"
+    /// Tombstone marking a refresh request that was dispatched to the server
+    /// but whose response we may not have received. A stale value surviving a
+    /// process kill indicates the rotation-orphan state.
+    case refreshInFlight = "fe_refresh_in_flight"
 }
 
 

--- a/Tests/FronteggSwiftTests/FronteggAuthRefreshRotationTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthRefreshRotationTests.swift
@@ -1,0 +1,382 @@
+//
+//  FronteggAuthRefreshRotationTests.swift
+//  FronteggSwiftTests
+//
+
+import XCTest
+@testable import FronteggSwift
+
+/// In-memory `CredentialManager` — the iOS simulator rejects real keychain
+/// writes with errSecMissingEntitlement in SPM test bundles.
+private final class InMemoryCredentialManager: CredentialManager {
+    private let lock = NSLock()
+    private var store: [String: String] = [:]
+
+    override func save(key: String, value: String) throws {
+        lock.withLock { store[key] = value }
+    }
+
+    override func get(key: String) throws -> String? {
+        lock.withLock { store[key] }
+    }
+
+    override func delete(key: String) {
+        _ = lock.withLock { store.removeValue(forKey: key) }
+    }
+
+    override func clear() {
+        lock.withLock { store.removeAll() }
+    }
+
+    override func clear(excludingKeys: [String]) {
+        lock.withLock {
+            store = store.filter { excludingKeys.contains($0.key) }
+        }
+    }
+}
+
+private final class MockRotationApi: Api {
+    private(set) var refreshCallCount = 0
+    private(set) var sentRefreshTokens: [String] = []
+    private(set) var meCallCount = 0
+
+    /// What `refreshToken(...)` returns once `refreshGate` (if set) is released.
+    var refreshResult: Result<AuthResponse, Error>?
+
+    /// Artificial delay inside `refreshToken(...)` before returning. Used to
+    /// simulate a slow network for the serialization test. Ignored when
+    /// `refreshGate` is configured.
+    var refreshDelayNanos: UInt64 = 0
+
+    /// When set, `refreshToken(...)` awaits this continuation before returning.
+    /// Tests can use this to hold the refresh mid-flight, mutate auth state
+    /// (e.g. simulate another path rotating the token), and then resume.
+    private var heldGate: CheckedContinuation<Void, Never>?
+    private var gateEntered: XCTestExpectation?
+
+    var meFailure: Error?
+    var meResult: MeResult?
+
+    init() {
+        super.init(baseUrl: "https://test.example.com", clientId: "test-client-id", applicationId: nil)
+    }
+
+    func installRefreshGate(entered expectation: XCTestExpectation) {
+        self.gateEntered = expectation
+    }
+
+    /// Releases the refresh call that is currently waiting on the gate.
+    /// Must be called exactly once after `installRefreshGate`.
+    func releaseRefreshGate() {
+        let continuation = heldGate
+        heldGate = nil
+        continuation?.resume()
+    }
+
+    override func refreshToken(
+        refreshToken: String,
+        tenantId: String? = nil,
+        accessToken: String? = nil
+    ) async throws -> AuthResponse {
+        refreshCallCount += 1
+        sentRefreshTokens.append(refreshToken)
+
+        if let gateEntered = gateEntered {
+            self.gateEntered = nil
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                self.heldGate = cont
+                gateEntered.fulfill()
+            }
+        } else if refreshDelayNanos > 0 {
+            try? await Task.sleep(nanoseconds: refreshDelayNanos)
+        }
+
+        guard let refreshResult else {
+            throw ApiError.invalidUrl("no refresh result configured")
+        }
+        switch refreshResult {
+        case .success(let response):
+            return response
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    override func me(accessToken: String, refreshToken: String) async throws -> MeResult {
+        meCallCount += 1
+        if let meFailure {
+            throw meFailure
+        }
+        if let meResult {
+            return meResult
+        }
+        return try await super.me(accessToken: accessToken, refreshToken: refreshToken)
+    }
+}
+
+final class FronteggAuthRefreshRotationTests: XCTestCase {
+    private var auth: FronteggAuth!
+    private var api: MockRotationApi!
+    private var credentialManager: InMemoryCredentialManager!
+    private var serviceKey: String!
+
+    override func setUp() {
+        super.setUp()
+        NetworkStatusMonitor._testReset()
+
+        serviceKey = "frontegg-refresh-rotation-\(UUID().uuidString)"
+        credentialManager = InMemoryCredentialManager(serviceKey: serviceKey)
+        PlistHelper.testConfigOverride = makeConfig(serviceKey: serviceKey, enableOfflineMode: true)
+        FronteggAuth.testNetworkPathAvailabilityOverride = true
+
+        auth = FronteggAuth(
+            baseUrl: "https://test.example.com",
+            clientId: "test-client-id",
+            applicationId: nil,
+            credentialManager: credentialManager,
+            isRegional: false,
+            regionData: [],
+            embeddedMode: false,
+            isLateInit: true,
+            entitlementsEnabled: false
+        )
+        api = MockRotationApi()
+        auth.api = api
+        auth.setInitializing(false)
+        auth.setIsLoading(false)
+        auth.setShowLoader(false)
+        auth.setWebLoading(false)
+        auth.setAccessToken(nil)
+        auth.setUser(nil)
+        auth.setIsAuthenticated(false)
+        credentialManager.clear()
+    }
+
+    override func tearDown() {
+        auth.cancelScheduledTokenRefresh()
+        NetworkStatusMonitor._testReset()
+        credentialManager.clear()
+        PlistHelper.testConfigOverride = nil
+        FronteggAuth.testNetworkPathAvailabilityOverride = nil
+        api = nil
+        auth = nil
+        credentialManager = nil
+        serviceKey = nil
+        super.tearDown()
+    }
+
+    // MARK: - Rotation-orphan persistence
+
+    func test_refreshTokenIfNeeded_persistsRotatedTokensToKeychainBeforePostRefreshWork() async throws {
+        try credentialManager.save(key: KeychainKeys.refreshToken.rawValue, value: "RT_OLD")
+        try credentialManager.save(key: KeychainKeys.accessToken.rawValue, value: "AT_OLD")
+        auth.setRefreshToken("RT_OLD")
+
+        let rotatedAccess = try makeAccessToken(email: "rotation@example.com", tenantId: "tenant-123")
+        api.refreshResult = .success(try makeAuthResponse(accessToken: rotatedAccess, refreshToken: "RT_NEW"))
+        // /me must fail non-connectivity so setCredentialsInternal hits
+        // clearAuthStateAfterHydrationFailure (wipes memory but not keychain).
+        api.meFailure = ApiError.meEndpointFailed(statusCode: 500, path: "identity/resources/users/v2/me")
+
+        let refreshed = await auth.refreshTokenIfNeeded()
+
+        XCTAssertFalse(refreshed, "hydration must fail so we can observe the post-fail keychain state")
+
+        let persistedRefresh = try credentialManager.get(key: KeychainKeys.refreshToken.rawValue)
+        let persistedAccess = try credentialManager.get(key: KeychainKeys.accessToken.rawValue)
+        XCTAssertEqual(persistedRefresh, "RT_NEW", "rotated refresh token must be persisted before post-refresh work")
+        XCTAssertEqual(persistedAccess, rotatedAccess)
+        XCTAssertEqual(api.sentRefreshTokens, ["RT_OLD"])
+    }
+
+    // MARK: - Serialization of concurrent refresh callers
+
+    func test_refreshTokenIfNeeded_concurrentCallers_performOnlyOneNetworkRefresh() async throws {
+        seedInMemorySessionWithCachedUser(email: "serial@example.com")
+
+        let rotatedAccess = try makeAccessToken(email: "serial@example.com", tenantId: "tenant-123")
+        api.refreshResult = .success(try makeAuthResponse(accessToken: rotatedAccess, refreshToken: "RT_NEW"))
+        api.refreshDelayNanos = 200_000_000
+
+        async let r1 = auth.refreshTokenIfNeeded()
+        async let r2 = auth.refreshTokenIfNeeded()
+        async let r3 = auth.refreshTokenIfNeeded()
+        let results = await (r1, r2, r3)
+
+        XCTAssertEqual(api.refreshCallCount, 1, "concurrent refresh callers must collapse to one network request")
+        XCTAssertEqual(api.sentRefreshTokens, ["RT_OLD"])
+        XCTAssertEqual(results.0, results.1)
+        XCTAssertEqual(results.1, results.2)
+        XCTAssertTrue(results.0)
+    }
+
+    func test_refreshTokenIfNeeded_serialRefreshAfterConcurrentGroup_startsNewRequest() async throws {
+        seedInMemorySessionWithCachedUser(email: "serial-after@example.com")
+
+        let firstAccess = try makeAccessToken(email: "serial-after@example.com", tenantId: "tenant-123")
+        api.refreshResult = .success(try makeAuthResponse(accessToken: firstAccess, refreshToken: "RT_INTERMEDIATE"))
+        let firstResult = await auth.refreshTokenIfNeeded()
+        XCTAssertTrue(firstResult)
+
+        let secondAccess = try makeAccessToken(email: "serial-after@example.com", tenantId: "tenant-123")
+        api.refreshResult = .success(try makeAuthResponse(accessToken: secondAccess, refreshToken: "RT_FINAL"))
+        let secondResult = await auth.refreshTokenIfNeeded()
+        XCTAssertTrue(secondResult)
+
+        XCTAssertEqual(api.refreshCallCount, 2, "sequential callers must each trigger their own network request")
+        XCTAssertEqual(api.sentRefreshTokens, ["RT_OLD", "RT_INTERMEDIATE"])
+        XCTAssertEqual(auth.refreshToken, "RT_FINAL")
+    }
+
+    // MARK: - RT-change guard
+
+    func test_refreshTokenIfNeeded_failedToRefreshToken_preservesCredentials_whenInMemoryRefreshTokenWasRotated() async throws {
+        auth.setRefreshToken("RT_OLD")
+        auth.setAccessToken("AT_OLD")
+        auth.setIsAuthenticated(true)
+
+        let gateEntered = expectation(description: "refresh entered")
+        api.installRefreshGate(entered: gateEntered)
+        api.refreshResult = .failure(
+            FronteggError.authError(.failedToRefreshToken("Refresh token could not be found"))
+        )
+
+        let refreshTask = Task { await auth.refreshTokenIfNeeded() }
+
+        await fulfillment(of: [gateEntered], timeout: 2.0)
+
+        await MainActor.run {
+            self.auth.setRefreshToken("RT_NEWER_FROM_SIDE_CHANNEL")
+        }
+
+        api.releaseRefreshGate()
+        let refreshed = await refreshTask.value
+
+        XCTAssertFalse(refreshed)
+        XCTAssertEqual(auth.refreshToken, "RT_NEWER_FROM_SIDE_CHANNEL")
+        XCTAssertEqual(auth.accessToken, "AT_OLD")
+        XCTAssertTrue(auth.isAuthenticated)
+    }
+
+    func test_refreshTokenIfNeeded_failedToRefreshToken_clearsCredentials_whenInMemoryRefreshTokenUnchanged() async throws {
+        auth.setRefreshToken("RT_OLD")
+        auth.setAccessToken("AT_OLD")
+        auth.setIsAuthenticated(true)
+
+        api.refreshResult = .failure(
+            FronteggError.authError(.failedToRefreshToken("Refresh token could not be found"))
+        )
+
+        let refreshed = await auth.refreshTokenIfNeeded()
+
+        XCTAssertFalse(refreshed)
+        XCTAssertNil(auth.refreshToken)
+        XCTAssertNil(auth.accessToken)
+        XCTAssertFalse(auth.isAuthenticated)
+    }
+
+    // MARK: - Refresh-token timeout plist
+
+    func test_api_resolveRefreshTokenTimeout_returnsPlistValue_whenAboveFloor() {
+        PlistHelper.testConfigOverride = makeConfig(serviceKey: serviceKey, enableOfflineMode: false, refreshTokenTimeout: 25)
+        let api = Api(baseUrl: "https://test.example.com", clientId: "test-client-id", applicationId: nil)
+        XCTAssertEqual(api.resolveRefreshTokenTimeout(), 25)
+    }
+
+    func test_api_resolveRefreshTokenTimeout_clampsToTenSeconds_whenPlistUnderfloors() {
+        PlistHelper.testConfigOverride = makeConfig(serviceKey: serviceKey, enableOfflineMode: false, refreshTokenTimeout: 3)
+        let api = Api(baseUrl: "https://test.example.com", clientId: "test-client-id", applicationId: nil)
+        XCTAssertGreaterThanOrEqual(api.resolveRefreshTokenTimeout(), 10)
+    }
+
+    func test_api_resolveRefreshTokenTimeout_usesTwentySecondDefault_whenPlistAbsent() {
+        PlistHelper.testConfigOverride = nil
+        let api = Api(baseUrl: "https://test.example.com", clientId: "test-client-id", applicationId: nil)
+        XCTAssertEqual(api.resolveRefreshTokenTimeout(), 20)
+    }
+
+    // MARK: - Helpers
+
+    /// Seeds tokens + a cached user so `setCredentialsInternal` takes the
+    /// "existingUser, tenant unchanged" fast path and skips /me.
+    private func seedInMemorySessionWithCachedUser(email: String, tenantId: String = "tenant-123") {
+        auth.setRefreshToken("RT_OLD")
+        auth.setAccessToken("AT_OLD")
+        do {
+            auth.setUser(try makeUser(email: email, tenantId: tenantId))
+        } catch {
+            XCTFail("Failed to build cached user: \(error)")
+        }
+        auth.setIsAuthenticated(true)
+    }
+
+    private func makeConfig(
+        serviceKey: String,
+        enableOfflineMode: Bool,
+        refreshTokenTimeout: TimeInterval = 20
+    ) -> FronteggPlist {
+        FronteggPlist(
+            keychainService: serviceKey,
+            embeddedMode: true,
+            loginWithSocialLogin: true,
+            handleLoginWithCustomSocialLoginProvider: true,
+            handleLoginWithSocialProvider: true,
+            loginWithSSO: true,
+            loginWithCustomSSO: true,
+            lateInit: false,
+            logLevel: .warn,
+            payload: .singleRegion(
+                .init(baseUrl: "https://test.example.com", clientId: "test-client-id")
+            ),
+            keepUserLoggedInAfterReinstall: true,
+            useAsWebAuthenticationForAppleLogin: true,
+            shouldSuggestSavePassword: false,
+            deleteCookieForHostOnly: true,
+            enableOfflineMode: enableOfflineMode,
+            useLegacySocialLoginFlow: false,
+            enableSessionPerTenant: false,
+            networkMonitoringInterval: 1,
+            enableSentryLogging: false,
+            sentryMaxQueueSize: 10,
+            entitlementsEnabled: false,
+            refreshTokenTimeout: refreshTokenTimeout
+        )
+    }
+
+    private func makeAuthResponse(accessToken: String, refreshToken: String) throws -> AuthResponse {
+        let json = TestDataFactory.makeAuthResponse(
+            refreshToken: refreshToken,
+            accessToken: accessToken
+        )
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(AuthResponse.self, from: data)
+    }
+
+    private func makeAccessToken(
+        email: String,
+        tenantId: String = "tenant-123",
+        expirationOffset: TimeInterval = 3600
+    ) throws -> String {
+        let payload: [String: Any] = [
+            "sub": UUID().uuidString,
+            "email": email,
+            "name": "Rotation User",
+            "tenantId": tenantId,
+            "tenantIds": [tenantId],
+            "exp": Int(Date().timeIntervalSince1970 + expirationOffset)
+        ]
+        return try TestDataFactory.makeJWT(payloadDict: payload)
+    }
+
+    private func makeUser(email: String, tenantId: String = "tenant-123") throws -> User {
+        let tenant = TestDataFactory.makeTenant(id: tenantId, name: "Tenant \(tenantId)", tenantId: tenantId)
+        let data = try JSONSerialization.data(withJSONObject: TestDataFactory.makeUser(
+            email: email,
+            tenantId: tenantId,
+            tenantIds: [tenantId],
+            tenants: [tenant],
+            activeTenant: tenant
+        ))
+        return try JSONDecoder().decode(User.self, from: data)
+    }
+}

--- a/Tests/FronteggSwiftTests/FronteggAuthRefreshRotationTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthRefreshRotationTests.swift
@@ -275,6 +275,80 @@ final class FronteggAuthRefreshRotationTests: XCTestCase {
         XCTAssertFalse(auth.isAuthenticated)
     }
 
+    // MARK: - Proactive refresh offset
+
+    func test_calculateOffset_usesFiftyPercentOfRemainingTtl_whenAboveMinWindow() {
+        // 600 s remaining → expect ~300 s offset (50%), not the old 480 s (80%).
+        let now = Date().timeIntervalSince1970
+        let offset = auth.calculateOffset(expirationTime: Int(now) + 600)
+        XCTAssertEqual(offset, 300, accuracy: 2.0, "offset must refresh at 50% of remaining TTL")
+    }
+
+    func test_calculateOffset_clampsToMinRefreshWindow_whenNearExpiry() {
+        // 10 s remaining — below 20 s minRefreshWindow — offset clamps to 0.
+        let now = Date().timeIntervalSince1970
+        let offset = auth.calculateOffset(expirationTime: Int(now) + 10)
+        XCTAssertEqual(offset, 0, accuracy: 0.5)
+    }
+
+    // MARK: - Refresh-in-flight tombstone
+
+    func test_refreshTokenIfNeeded_successfulRefresh_clearsRefreshInFlightTombstone() async throws {
+        seedInMemorySessionWithCachedUser(email: "tombstone-success@example.com")
+
+        let rotatedAccess = try makeAccessToken(email: "tombstone-success@example.com", tenantId: "tenant-123")
+        api.refreshResult = .success(try makeAuthResponse(accessToken: rotatedAccess, refreshToken: "RT_NEW"))
+
+        let refreshed = await auth.refreshTokenIfNeeded()
+
+        XCTAssertTrue(refreshed)
+        XCTAssertNil(
+            try credentialManager.get(key: KeychainKeys.refreshInFlight.rawValue),
+            "tombstone must be cleared after a refresh that completed + persisted"
+        )
+    }
+
+    func test_refreshTokenIfNeeded_interruptedRefresh_leavesTombstoneForNextLaunch() async throws {
+        auth.setRefreshToken("RT_OLD")
+        auth.setAccessToken("AT_OLD")
+        auth.setIsAuthenticated(true)
+
+        // Connectivity failure mid-request — we cannot know whether the server
+        // processed the rotation, so the tombstone must survive for the next
+        // launch to observe the orphan.
+        api.refreshResult = .failure(URLError(.timedOut))
+
+        _ = await auth.refreshTokenIfNeeded()
+
+        let tombstone = try credentialManager.get(key: KeychainKeys.refreshInFlight.rawValue)
+        XCTAssertNotNil(tombstone, "tombstone must survive a connectivity failure")
+        XCTAssertEqual(tombstone, auth.refreshTokenFingerprint("RT_OLD"))
+    }
+
+    func test_refreshTokenIfNeeded_failedToRefreshToken_clearsTombstone_onDefinitiveRejection() async throws {
+        auth.setRefreshToken("RT_OLD")
+        auth.setAccessToken("AT_OLD")
+        auth.setIsAuthenticated(true)
+
+        api.refreshResult = .failure(
+            FronteggError.authError(.failedToRefreshToken("Refresh token could not be found"))
+        )
+
+        _ = await auth.refreshTokenIfNeeded()
+
+        XCTAssertNil(
+            try credentialManager.get(key: KeychainKeys.refreshInFlight.rawValue),
+            "tombstone must be cleared after definitive server rejection — there is no unresolved in-flight request anymore"
+        )
+    }
+
+    func test_hasOrphanedRefreshTombstone_matchesByFingerprint() {
+        auth.writeRefreshInFlightTombstone(for: "RT_FROM_PREVIOUS_PROCESS")
+        XCTAssertTrue(auth.hasOrphanedRefreshTombstone(matching: "RT_FROM_PREVIOUS_PROCESS"))
+        XCTAssertFalse(auth.hasOrphanedRefreshTombstone(matching: "DIFFERENT_TOKEN"))
+        XCTAssertFalse(auth.hasOrphanedRefreshTombstone(matching: nil))
+    }
+
     // MARK: - Refresh-token timeout plist
 
     func test_api_resolveRefreshTokenTimeout_returnsPlistValue_whenAboveFloor() {


### PR DESCRIPTION
## Summary

Intermittent logouts (~1 in 100–1000 under weak network, most often after a push-notification wake-up) were caused by the client's old refresh token being consumed server-side without the new one ever reaching durable storage.

Five interlocking fixes close the rotation-orphan window. Each is independently useful; together they eliminate every reproducible path to a spurious logout.

Oosto case: `oidc_token.exchange.failed` / *"Refresh token could not be found"* — server had already rotated, client never persisted RT_NEW.

## Fixes

### Commit 1 — five core fixes

1. **Immediate keychain persistence** of rotated tokens — runs right after the refresh response, before `setCredentialsInternal`/`/me`. If the process is suspended or killed mid-hydration, RT_NEW is already durable.
2. **Refresh timeout raised from 5s → 20s** (plist-configurable, clamped to a 10s floor). The old 5s dropped the socket while the server had already rotated the token under weak Wi-Fi / cellular.
3. **`UIApplication.beginBackgroundTask`** around the refresh so iOS cannot force-suspend the app between the request and the keychain write. Expiration handler releases the task cleanly.
4. **Serialize concurrent refreshes** via an inflight `Task<Bool, Never>` + lock. `applicationDidBecomeActive`, scheduled refresh, `reconnectedToInternet`, and manual user refresh previously could all fire the same RT in parallel; one would rotate it and the others would log out on the 401.
5. **Defense-in-depth credential-clear guard**: if the in-memory RT differs from the one we just sent when the server returns `failedToRefreshToken`, do NOT wipe credentials — another path has already rotated the token and the current one may still be valid.

### Commit 2 — hardening

After manual testing surfaced a remaining window where a force-killed process with a refresh on the wire could still lose the session, two additional client-side hardenings stacked on top:

6. **Earlier proactive refresh**: scheduled refresh fires at **50% of remaining TTL** instead of 80%. Rotations now land with comfortable headroom instead of near expiry, so urgent on-activate refreshes are rarer.
7. **Pre-refresh tombstone**: before every refresh request we write `fe_refresh_in_flight = sha256(RT)[:8]` to the keychain, and clear it after successful persistence. If the process is force-killed before the response lands, the tombstone survives. On the next launch we emit a Sentry breadcrumb attributing any subsequent `failed_to_refresh_token` to an interrupted rotation (via a `followsInterruptedRefresh: true` tag) rather than a truly invalid token. This does not itself recover the session — that requires a server-side grace period on rotation — but it makes the residual orphan rate observable so the need for a deeper fix (silent-auth recovery or backend grace window) can be decided from data.

## Files changed

| File | What |
| --- | --- |
| `Sources/FronteggSwift/models/plist/FronteggPlist.swift` | new `refreshTokenTimeout` (default 20, floor 10) |
| `Sources/FronteggSwift/services/Api.swift` | `refreshToken(...)` reads plist timeout via `resolveRefreshTokenTimeout()` — no signature change |
| `Sources/FronteggSwift/services/CredentialManager.swift` | new `refreshInFlight` keychain key |
| `Sources/FronteggSwift/FronteggAuth.swift` | `refreshSerializationLock` + `inflightRefreshTask` properties |
| `Sources/FronteggSwift/auth/FronteggAuth+Refresh.swift` | background-task handle, immediate-persistence, serialization, RT-change guard, tombstone helpers, 50% offset |
| `Sources/FronteggSwift/auth/FronteggAuth+SessionRestore.swift` | startup detection of orphaned-refresh tombstone |
| `Tests/FronteggSwiftTests/FronteggAuthRefreshRotationTests.swift` | 14 regression tests (new file) |

## What was deliberately NOT touched

- `api.refreshToken` signature — kept identical so every existing mock (e.g. `MockRefreshRecoveryApi`) keeps compiling.
- Offline-mode and SessionPerTenant paths — the new immediate-persistence reuses the same tenant-resolution order already used by `setCredentialsInternal`, so the later save is idempotent.
- The existing `self.refreshingToken` early-return — the new serialization is strictly additive; anything that reads that flag still works.

## Test plan

- [x] `FronteggAuthRefreshRotationTests` — 14 tests, all pass
  - [x] rotated tokens persisted to keychain before post-refresh work
  - [x] 3 concurrent callers → 1 network request
  - [x] serial refresh AFTER concurrent group → fresh request (no stale coalescing)
  - [x] RT-change guard preserves credentials when side-channel rotated RT
  - [x] control: unchanged RT + 401 still clears credentials (no over-protection)
  - [x] plist timeout: reads value, clamps to 10s floor, falls back to 20s default
  - [x] proactive refresh offset: 50% of remaining TTL at comfortable lives; clamps near expiry
  - [x] tombstone: cleared on success, survives connectivity interruption, cleared on definitive 401, fingerprint matching
- [x] Full `FronteggSwift` test suite: **658 passed, 0 regressions** (644 pre-existing + 14 new)
- [x] `demo` app builds for iOS Simulator
- [ ] Manual smoke test on device under weak network + push notification (owner to run)
- [ ] Stage rollout behind a monitor on `oidc_token.exchange.failed` rate in Coralogix / Sentry

## QA verification (demo apps have no push)

Demo apps don't need push — push is just one of many triggers for "app runs briefly under a shaky network". Any other way of interrupting a refresh reproduces the same race.

**Tier 1 — automated:** `FronteggAuthRefreshRotationTests` proves four of five core protections + both hardenings in isolation.

**Tier 2 — Network Link Conditioner:** on device, enable "Very Bad Network" → background the app 60 s → foreground → kill from app switcher → disable NLC → relaunch. Before the fix, ~1 in 10 attempts logs the user out; after, 0 in 50.

**Tier 3 — deterministic breakpoint kill:** in Xcode, breakpoint on the line immediately after the refresh API call returns in `performRefreshTokenFlow`, trigger a refresh, force-kill the process when it hits, relaunch — session must be restored.

**Tier 4 — log grep:** on any successful refresh, `Refreshing token via oauth/token (timeout: 20s)` and `Persisted rotated tokens to keychain ... immediately after refresh` must both appear.

**Tier 5 — production:** the real signal is a drop in `oidc_token.exchange.failed` rate in Coralogix within 48 h of rollout. The new `followsInterruptedRefresh` tag on residual failures tells you whether the remaining ones are genuine invalid tokens (→ normal) or force-kill orphans (→ needs server grace period).

## Rollout notes

- No breaking API changes. Existing plists continue to work (new field has a 20 s default).
- Host apps wanting a different timeout can set `refreshTokenTimeout` in their plist. The hard-coded 10 s floor intentionally blocks going below that to prevent a mis-configuration from reviving this bug.
- The proactive-refresh shift from 80% to 50% roughly doubles the refresh call rate per active session. Still well under server-side rate limits.

Ref: TKT-36495
