### PR TITLE
ci: stop inlining PR description into shell-quoted strings

### DIFF
--- a/.github/workflows/onPullRequestMerged.yaml
+++ b/.github/workflows/onPullRequestMerged.yaml
@@ -95,22 +95,31 @@ jobs:
       - name: Update CHANGELOG file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass DESCRIPTION through the environment so bash sees it as a
+          # plain variable. Inlining ${{ ... }} into a shell-quoted string
+          # breaks when the PR body contains apostrophes (e.g. "host's",
+          # "portal's") — the single-quoted heredoc closes early and bash
+          # then mis-parses the rest as commands. See the failure on
+          # https://github.com/frontegg/frontegg-ios-swift/actions/runs/25501763514
+          DESCRIPTION: ${{ steps.get_description.outputs.DESCRIPTION }}
         shell: bash
         run: |
-          if [[ -f "${{ env.CHANGELOG_FILE }}" ]]; then
-            cp "${{ env.CHANGELOG_FILE }}" "${{ env.CHANGELOG_OLD_FILE }}"
+          if [[ -f "$CHANGELOG_FILE" ]]; then
+            cp "$CHANGELOG_FILE" "$CHANGELOG_OLD_FILE"
           else
             echo "WARNING: CHANGELOG_FILE does not exist!"
           fi
-          
-          
-          # Append PR description to CHANGELOG_FILE safely
-          if [[ -f "${{ env.CHANGELOG_FILE }}" ]]; then
-            CHANGELOG_FILE_CONTENT="$(cat ${{ env.CHANGELOG_FILE }})"
-            echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
-            echo -e "\n$CHANGELOG_FILE_CONTENT" >> ${{ env.CHANGELOG_FILE }}
+
+
+          # Append PR description to CHANGELOG_FILE safely. printf is more
+          # portable than `echo -e` and won't choke on backslashes inside
+          # the PR body.
+          if [[ -f "$CHANGELOG_FILE" ]]; then
+            CHANGELOG_FILE_CONTENT="$(cat "$CHANGELOG_FILE")"
+            printf '%s\n' "$DESCRIPTION" > "$CHANGELOG_FILE"
+            printf '\n%s\n' "$CHANGELOG_FILE_CONTENT" >> "$CHANGELOG_FILE"
           else
-            echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
+            printf '%s\n' "$DESCRIPTION" > "$CHANGELOG_FILE"
           fi
 
       - name: Commit changes

--- a/.github/workflows/onReleasePullRequestUpdated.yaml
+++ b/.github/workflows/onReleasePullRequestUpdated.yaml
@@ -39,12 +39,18 @@ jobs:
           # Extract the description (body field)
           DESCRIPTION=$(echo "$pr_metadata" | jq -r '.body // ""')
           
-          # Check if DESCRIPTION is valid
+          # Check if DESCRIPTION is valid. Use printf + the $DESCRIPTION env
+          # variable instead of inlining ${{ ... }} into a shell-quoted
+          # string — apostrophes in the PR body (e.g. "host's", "page's")
+          # would close the single-quote early and break parsing.
           if [[ -n "$DESCRIPTION" && "$DESCRIPTION" != "null" ]]; then
-            if [[ -f "${{ env.CHANGELOG_OLD_FILE }}" ]]; then
-              echo -e "$DESCRIPTION\n\n$(cat ${{ env.CHANGELOG_OLD_FILE }})" > ${{ env.CHANGELOG_FILE }}
+            if [[ -f "$CHANGELOG_OLD_FILE" ]]; then
+              {
+                printf '%s\n\n' "$DESCRIPTION"
+                cat "$CHANGELOG_OLD_FILE"
+              } > "$CHANGELOG_FILE"
             else
-              echo '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
+              printf '%s\n' "$DESCRIPTION" > "$CHANGELOG_FILE"
             fi
           else
             echo "No description provided in the pull request. The 'release/next' branch must provide a description for correct CHANGELOG.md generation."


### PR DESCRIPTION
The release workflows wrote the PR body to CHANGELOG.md by inlining the GitHub Actions expression `${{ steps.get_description.outputs.DESCRIPTION }}` inside a single-quoted bash string:

    echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > $CHANGELOG

Whenever the PR body contained an apostrophe ("host's", "page's", "portal's", any English contraction), the single quote inside the expanded string closed the literal early, then bash mis-parsed the remainder as commands — exit 2, "syntax error near unexpected token `('".

This bit the merge of #253 and would bite every future PR with contraction-style English in the description (i.e. nearly all of them). Failed run:
https://github.com/frontegg/frontegg-ios-swift/actions/runs/25501763514

Fix in both onPullRequestMerged.yaml and onReleasePullRequestUpdated.yaml:

- Pass DESCRIPTION via `env:` so bash dereferences it as $DESCRIPTION with no escaping required.
- Reference all paths via env vars ($CHANGELOG_FILE, $CHANGELOG_OLD_FILE) instead of ${{ env.X }} so the bash invocation is fully shell-quoted.
- Replace `echo -e '...' > FILE` with `printf '%s\n' "$VAR" > "$FILE"` — printf is portable and won't choke on backslashes inside the body.