### PR TITLE
FR-24822 - Enhance route availability checks to prevent crashes from multiple resumes

### DIFF
--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -549,14 +549,56 @@ public enum NetworkStatusMonitor {
         }
     }
 
-    private static func routeIsAvailableOnce() async -> Bool {
-        await withCheckedContinuation { cont in
+    /// Bridges a callback-based API that may invoke `resume` more than once into a single
+    /// async result. The first call to `resume` wins; later calls are silently dropped.
+    ///
+    /// This exists because `NWPathMonitor.pathUpdateHandler` is invoked once at start *and* on
+    /// every subsequent path change (Wi-Fi ↔ cellular handoff, VPN reconnect, captive-portal
+    /// auth, sleep/wake). Resuming a `CheckedContinuation` more than once trips
+    /// `_checkedContinuationViolated` and crashes the process with `EXC_BREAKPOINT`. Even
+    /// cancelling the monitor before resuming is not enough: callbacks already enqueued on
+    /// the serial path queue still run after `cancel()`. The lock-guarded boolean here is the
+    /// authoritative gate.
+    private static func awaitFirstBoolResult(
+        body: (@escaping (Bool) -> Void) -> Void
+    ) async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            let lock = NSLock()
+            var didResume = false
+            body { value in
+                let shouldResume: Bool = lock.withLock {
+                    guard !didResume else { return false }
+                    didResume = true
+                    return true
+                }
+                guard shouldResume else { return }
+                cont.resume(returning: value)
+            }
+        }
+    }
+
+    /// One-shot route availability check. Returns `false` if the monitor does not
+    /// deliver a path update within `timeout`. Mirrors `FronteggAuth.checkNetworkPath`'s
+    /// defensive bound — without it, a stalled `NWPathMonitor` (VPN reconnect, MDM
+    /// captive portal) could hang the startup connectivity race indefinitely.
+    private static func routeIsAvailableOnce(timeout: TimeInterval = 1.0) async -> Bool {
+        await awaitFirstBoolResult { resume in
             let m = NWPathMonitor()
             m.pathUpdateHandler = { path in
-                cont.resume(returning: path.status == .satisfied)
+                let satisfied = path.status == .satisfied
+                m.pathUpdateHandler = nil
                 m.cancel()
+                resume(satisfied)
             }
             m.start(queue: pathQueue)
+
+            // Race the monitor against a deadline on the same serial queue so the
+            // cancel + resume are serialized w.r.t. any in-flight path update.
+            pathQueue.asyncAfter(deadline: .now() + timeout) {
+                m.pathUpdateHandler = nil
+                m.cancel()
+                resume(false)
+            }
         }
     }
 }
@@ -630,6 +672,19 @@ extension NetworkStatusMonitor {
 
     static func _testEmitCached(_ value: Bool, forceEmit: Bool = false) {
         updateCached(value, forceEmit: forceEmit)
+    }
+
+    /// Test seam that exposes the one-shot resume primitive used by `routeIsAvailableOnce`.
+    /// Used to verify the `EXC_BREAKPOINT` regression from issue #256 cannot return.
+    static func _testAwaitFirstBoolResult(
+        body: (@escaping (Bool) -> Void) -> Void
+    ) async -> Bool {
+        await awaitFirstBoolResult(body: body)
+    }
+
+    /// Test seam exposing the real `routeIsAvailableOnce` so we can smoke-test the wiring.
+    static func _testRouteIsAvailableOnce() async -> Bool {
+        await routeIsAvailableOnce()
     }
 
     static func _testSnapshot() -> (

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -584,21 +584,26 @@ public enum NetworkStatusMonitor {
     private static func routeIsAvailableOnce(timeout: TimeInterval = 1.0) async -> Bool {
         await awaitFirstBoolResult { resume in
             let m = NWPathMonitor()
-            m.pathUpdateHandler = { path in
-                let satisfied = path.status == .satisfied
-                m.pathUpdateHandler = nil
-                m.cancel()
-                resume(satisfied)
-            }
-            m.start(queue: pathQueue)
-
-            // Race the monitor against a deadline on the same serial queue so the
-            // cancel + resume are serialized w.r.t. any in-flight path update.
-            pathQueue.asyncAfter(deadline: .now() + timeout) {
+            // Build the deadline work item first so the path handler can cancel it
+            // when an update wins the race — without this, the deadline closure stays
+            // queued, keeps `m` alive until `timeout`, and fires a dropped
+            // cancel + resume(false) after the await has already resumed.
+            let timeoutItem = DispatchWorkItem {
                 m.pathUpdateHandler = nil
                 m.cancel()
                 resume(false)
             }
+            m.pathUpdateHandler = { path in
+                let satisfied = path.status == .satisfied
+                m.pathUpdateHandler = nil
+                m.cancel()
+                timeoutItem.cancel()
+                resume(satisfied)
+            }
+            m.start(queue: pathQueue)
+            // Race the monitor against a deadline on the same serial queue so the
+            // cancel + resume are serialized w.r.t. any in-flight path update.
+            pathQueue.asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
         }
     }
 }

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -276,6 +276,36 @@ final class NetworkStatusMonitorTests: XCTestCase {
         XCTAssertTrue(result, "first resume(true) must win; late resume(false) must be dropped")
     }
 
+    func test_awaitFirstBoolResult_cancellableTimeoutPattern_neverFiresWhenCancelled() async {
+        // Mirrors the production pattern in `routeIsAvailableOnce`: the body schedules a
+        // deadline `DispatchWorkItem` and the "winner" cancels it before its deadline.
+        // The gate alone (covered by the prior test) would still prevent a double-resume
+        // even if the work item ran — this test pins the *cancellation* behavior the
+        // implementation relies on for resource hygiene, so a future edit that removes
+        // `timeoutItem.cancel()` in `routeIsAvailableOnce` regresses a guarded invariant
+        // instead of silently reverting the optimization.
+        let queue = DispatchQueue(label: "test.cancellableTimeoutPattern")
+        let timeoutFired = expectation(description: "deadline work item must not run after cancel")
+        timeoutFired.isInverted = true
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            let timeoutItem = DispatchWorkItem {
+                timeoutFired.fulfill()
+                resume(false)
+            }
+            queue.async {
+                // Simulate the path-update handler winning the race: cancel the deadline
+                // before resuming so the deadline closure never runs.
+                timeoutItem.cancel()
+                resume(true)
+            }
+            queue.asyncAfter(deadline: .now() + 0.05, execute: timeoutItem)
+        }
+        // Wait past the scheduled deadline; the inverted expectation fails if the
+        // cancelled work item ever executes.
+        await fulfillment(of: [timeoutFired], timeout: 0.3)
+        XCTAssertTrue(result, "cancelled deadline must not poison the resumed value")
+    }
+
     func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {
         // Issues many overlapping invocations to maximise the chance of catching a
         // double-resume regression. Each call instantiates its own NWPathMonitor and

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -258,19 +258,22 @@ final class NetworkStatusMonitorTests: XCTestCase {
         // (which also calls `resume(false)` after `timeout` seconds) can never re-enter
         // a continuation that the path update already resumed.
         let queue = DispatchQueue(label: "test.lateSecondFire")
-        let firstFired = expectation(description: "first resume fired")
+        let lateFired = expectation(description: "late resume fired without crashing")
         let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            // First fire immediately on the serial queue — this wins the gate.
             queue.async {
                 resume(true)
-                firstFired.fulfill()
+            }
+            // Second fire arrives later on the same queue, after the await has
+            // already resumed. If the gate ever lets it through, the runtime
+            // will SIGTRAP on the double-resume of the continuation.
+            queue.asyncAfter(deadline: .now() + 0.05) {
+                resume(false)
+                lateFired.fulfill()
             }
         }
-        await fulfillment(of: [firstFired], timeout: 1.0)
-        // Now simulate the timeout closure arriving long after the first resume.
-        // We can't reach the same `resume` sink (it's local to the previous call),
-        // but we exercise the same invariant with a fresh helper invocation that
-        // gets called both immediately and "late" via the queue.
-        XCTAssertTrue(result)
+        await fulfillment(of: [lateFired], timeout: 1.0)
+        XCTAssertTrue(result, "first resume(true) must win; late resume(false) must be dropped")
     }
 
     func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -153,6 +153,158 @@ final class NetworkStatusMonitorTests: XCTestCase {
         XCTAssertFalse(snapshot.hasInitialCheckFired)
     }
 
+    // MARK: - One-shot CheckedContinuation safety (issue #256)
+    //
+    // `NWPathMonitor.pathUpdateHandler` is invoked once at start and again on every
+    // subsequent path change (Wi-Fi ↔ cellular handoff, VPN reconnect, sleep/wake).
+    // The previous `routeIsAvailableOnce()` implementation called
+    // `continuation.resume` directly inside that handler, so a second fire produced
+    // an `EXC_BREAKPOINT` from Swift's `_checkedContinuationViolated` precondition.
+    // These tests pin the new single-resume invariant: even under rapid, sequential,
+    // or massively concurrent re-entries of the callback, the continuation must be
+    // resumed at most once and the host process must not crash.
+    //
+    // The Swift runtime aborts the test process when a CheckedContinuation is resumed
+    // twice, so if any of these regress, the test target will SIGTRAP rather than fail
+    // a single assertion. That's intentional — it's the same signal customers saw.
+
+    func test_awaitFirstBoolResult_singleFire_returnsValue() async {
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            resume(true)
+        }
+        XCTAssertTrue(result)
+    }
+
+    func test_awaitFirstBoolResult_sequentialDoubleFire_doesNotCrash_andReturnsFirstValue() async {
+        // Simulates `NWPathMonitor` firing twice back-to-back on the same serial queue,
+        // which is exactly the case that produced the EXC_BREAKPOINT in production.
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            resume(true)
+            resume(false)
+            resume(true)
+        }
+        XCTAssertTrue(result, "First resume must win; subsequent resumes must be no-ops")
+    }
+
+    func test_awaitFirstBoolResult_asyncDoubleFire_doesNotCrash() async {
+        // Simulates the realistic ordering: handler is delivered on a background serial
+        // queue and fires again later as the path settles (VPN reconnect, captive portal).
+        let queue = DispatchQueue(label: "test.awaitFirstBoolResult.async")
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            queue.async {
+                resume(true)
+                // Even after a brief delay simulating a follow-up path change,
+                // resuming again must not trip the runtime precondition.
+                queue.asyncAfter(deadline: .now() + 0.01) {
+                    resume(false)
+                }
+            }
+        }
+        XCTAssertTrue(result)
+    }
+
+    func test_awaitFirstBoolResult_concurrentFiresFromManyThreads_doesNotCrash() async {
+        // Hammers the gate from multiple threads simultaneously. If the lock-guarded
+        // `didResume` flag ever lets two callers through, the runtime will SIGTRAP.
+        //
+        // We block synchronously inside the continuation body on `group.wait()` so
+        // every one of the 128 dispatched calls has actually been delivered to the
+        // gate before `body` returns. Without this wait, `body` could return (and the
+        // first `resume` could wake the await) before later closures even fire — the
+        // test would pass without genuinely exercising the concurrent re-entry path.
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            let group = DispatchGroup()
+            for index in 0..<128 {
+                group.enter()
+                DispatchQueue.global().async {
+                    // Mix true/false to also assert that "first wins" is the contract,
+                    // not "last wins" or some race-y blend.
+                    resume(index % 2 == 0)
+                    group.leave()
+                }
+            }
+            group.wait()
+        }
+        // Any caller could have been first — only the no-crash invariant matters here.
+        _ = result
+    }
+
+    func test_routeIsAvailableOnce_returnsBoolWithoutCrash() async {
+        // End-to-end smoke test against the real `NWPathMonitor`-backed implementation.
+        // The actual value depends on the test host's network, so we just assert
+        // the call completes — the regression we care about is the crash, not a value.
+        _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+    }
+
+    func test_routeIsAvailableOnce_completesWithinDeadline() async {
+        // Defensive bound: even if `NWPathMonitor` never delivers an update (a real
+        // edge case seen with stalled VPN/MDM profiles and on isolated CI runners),
+        // the call must not hang the caller. The internal timeout is 1s; we allow
+        // a generous 3s envelope to absorb scheduler jitter on slow CI.
+        let start = Date()
+        _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(
+            elapsed,
+            3.0,
+            "routeIsAvailableOnce must not hang when the path monitor is slow or stalled"
+        )
+    }
+
+    func test_awaitFirstBoolResult_lateSecondFireAfterResumeIsHarmless() async {
+        // Models the exact production timing: the first path-update resumes, then a
+        // second update arrives moments later from the same serial queue. The gate
+        // must drop the late call silently so the timeout path in `routeIsAvailableOnce`
+        // (which also calls `resume(false)` after `timeout` seconds) can never re-enter
+        // a continuation that the path update already resumed.
+        let queue = DispatchQueue(label: "test.lateSecondFire")
+        let firstFired = expectation(description: "first resume fired")
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            queue.async {
+                resume(true)
+                firstFired.fulfill()
+            }
+        }
+        await fulfillment(of: [firstFired], timeout: 1.0)
+        // Now simulate the timeout closure arriving long after the first resume.
+        // We can't reach the same `resume` sink (it's local to the previous call),
+        // but we exercise the same invariant with a fresh helper invocation that
+        // gets called both immediately and "late" via the queue.
+        XCTAssertTrue(result)
+    }
+
+    func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {
+        // Issues many overlapping invocations to maximise the chance of catching a
+        // double-resume regression. Each call instantiates its own NWPathMonitor and
+        // its own continuation, but they share `pathQueue`, so any serialization
+        // assumptions get exercised here too.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+                }
+            }
+        }
+    }
+
+    func test_probeConfiguredReachability_withoutConfiguredBaseURL_doesNotCrash() async {
+        // `probeConfiguredReachability()` falls through to `routeIsAvailableOnce()`
+        // when no base URL is configured. This is the exact call path used by
+        // `FronteggAuth.completeUnauthenticatedStartupInitialization` during the
+        // app-launch connectivity race, which is where customers saw the crash.
+        // The `_testReset()` in `setUp` ensures no base URL is configured.
+        _ = await NetworkStatusMonitor.probeConfiguredReachability()
+    }
+
+    func test_isActive_whenNotMonitoring_doesNotCrash() async {
+        // The 1.2.21 crash signature pointed at `NetworkStatusMonitor.isActive`,
+        // which on master delegates to `probeReachability` → `routeIsAvailableOnce`
+        // when background monitoring is inactive. Cover the same call shape.
+        let snapshot = NetworkStatusMonitor._testSnapshot()
+        XCTAssertFalse(snapshot.monitoringActive, "Sanity: setUp should leave monitoring inactive")
+        _ = await NetworkStatusMonitor.isActive
+    }
+
     @MainActor
     func test_staleMonitoringGeneration_doesNotNotifyHandlersAfterStop() {
         let notCalled = expectation(description: "Stale monitoring generation should not notify")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches async reachability probing and `NWPathMonitor` lifecycle/timeout behavior; incorrect gating or timing could cause false offline results or hangs, but scope is limited and well-covered by new tests.
> 
> **Overview**
> Hardens the one-shot reachability check used when no base URL is configured by preventing `CheckedContinuation` double-resumes from `NWPathMonitor.pathUpdateHandler` re-entrancy (the `EXC_BREAKPOINT` regression in issue #256).
> 
> `routeIsAvailableOnce()` is refactored to use a lock-guarded “first resume wins” bridge and now includes a 1s timeout raced on the same serial queue; DEBUG-only test seams plus a comprehensive new test suite exercise sequential/async/concurrent callback fires, deadline cancellation, repeated calls, and the `probeConfiguredReachability()` / `isActive` call paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e7fd95418a1b7c6fcb0cc887faf65ae7ec4133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->