### PR TITLE
FR-24598 - Prevent social success page from reloading during login flow to avoid authorization code resubmission

### DIFF
--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -27,9 +27,6 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private var isSocialLoginFlow: Bool = false
     private var socialSuccessWatchdogWorkItem: DispatchWorkItem? = nil
     private let socialSuccessWatchdogDelay: TimeInterval = 5.0
-    internal var socialSuccessRetryCount: Int = 0
-    internal let socialSuccessMaxRetries: Int = 2
-    internal var isWatchdogReload: Bool = false
 
     func setActiveOAuthFlow(_ flow: FronteggOAuthFlow) {
         fronteggAuth.activeEmbeddedOAuthFlow = flow
@@ -77,13 +74,34 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private func cancelSocialSuccessWatchdog() {
         socialSuccessWatchdogWorkItem?.cancel()
         socialSuccessWatchdogWorkItem = nil
-        socialSuccessRetryCount = 0
-        isWatchdogReload = false
     }
 
+    /// Outcome the social-success watchdog can take when it fires. Pure value
+    /// so the decision logic can be unit-tested without WKWebView/FronteggAuth.
+    ///
+    /// Crucially there is no `.reload` case: reloading
+    /// `/oauth/account/social/success` would re-submit the authorization
+    /// code, which fails the second post-login attempt and replaces a useful
+    /// server-rendered error (e.g. "Couldn't sign you in / Cannot resolve
+    /// user profile") with a generic one. Post-login can legitimately take
+    /// longer than the watchdog delay on a slow tenant, so we never reload.
+    internal enum SocialSuccessWatchdogAction: Equatable {
+        /// The page already navigated away from `/social/success` — no action.
+        case skip
+        /// Still on `/social/success` after the timeout — hide the SDK loader
+        /// so whatever the server rendered (its own loader, success page, or
+        /// error) becomes visible.
+        case hideLoader
+    }
+
+    internal static func socialSuccessWatchdogAction(currentPath: String) -> SocialSuccessWatchdogAction {
+        currentPath.contains("/oauth/account/social/success") ? .hideLoader : .skip
+    }
+
+    /// Schedule a single timeout that hides the SDK loader if the social
+    /// success page is still on-screen after `socialSuccessWatchdogDelay`.
+    /// See `SocialSuccessWatchdogAction` for the no-reload rationale.
     private func scheduleSocialSuccessWatchdog(for webView: WKWebView, url: URL) {
-        // Cancel the pending work item without resetting retryCount
-        // so that retry calls can track cumulative attempts.
         socialSuccessWatchdogWorkItem?.cancel()
         socialSuccessWatchdogWorkItem = nil
 
@@ -91,37 +109,15 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             guard let self = self, let webView = webView else { return }
             let currentUrl = webView.url ?? url
 
-            guard currentUrl.path.contains("/oauth/account/social/success") else {
+            switch Self.socialSuccessWatchdogAction(currentPath: currentUrl.path) {
+            case .skip:
                 return
-            }
-
-            // The social success page is still showing after the timeout. The
-            // server-side provider code exchange (e.g. Google → Frontegg) either
-            // failed or stalled. Do NOT extract the provider code and send it to
-            // /oauth/token — that endpoint expects a Frontegg authorization code.
-            // Instead, retry by reloading the page so the server can re-attempt
-            // the exchange. After max retries, hide the loader to reveal any
-            // server-rendered error message.
-            if self.socialSuccessRetryCount < self.socialSuccessMaxRetries {
-                self.socialSuccessRetryCount += 1
-                self.logger.warning(
-                    "Social login success page stalled (attempt \(self.socialSuccessRetryCount)/\(self.socialSuccessMaxRetries)), reloading to retry server-side exchange"
+            case .hideLoader:
+                self.logger.info(
+                    "Social login success page still on-screen after \(self.socialSuccessWatchdogDelay)s; hiding SDK loader so any server-rendered content is visible (no reload — would break in-flight post-login)"
                 )
-                DispatchQueue.main.async { [weak self, weak webView] in
-                    guard let self = self, let webView = webView else { return }
-                    self.isWatchdogReload = true
-                    webView.reload()
-                    // Re-schedule watchdog for the reload
-                    self.scheduleSocialSuccessWatchdog(for: webView, url: url)
-                }
-            } else {
-                self.logger.warning(
-                    "Social login success page stalled after \(self.socialSuccessMaxRetries) retries, hiding loader to reveal server response"
-                )
-                DispatchQueue.main.async { [weak self] in
-                    self?.fronteggAuth.setWebLoading(false)
-                    self?.fronteggAuth.setLoginBoxLoading(false)
-                }
+                self.fronteggAuth.setWebLoading(false)
+                self.fronteggAuth.setLoginBoxLoading(false)
             }
         }
 
@@ -658,14 +654,6 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                         } else {
                             logger.info("🔵 [Social Login Debug] /social/success detected as intermediate page (Google case, previousUrl was HTTPS/nil) - allowing normal navigation")
                             isSocialLoginFlow = true
-                            if isWatchdogReload {
-                                // Watchdog-triggered reload — preserve the retry counter so
-                                // the watchdog can reach maxRetries and stop.
-                                isWatchdogReload = false
-                            } else {
-                                // Genuinely fresh social login flow — reset counter.
-                                socialSuccessRetryCount = 0
-                            }
                             scheduleSocialSuccessWatchdog(for: webView, url: url)
                             return .allow
                         }

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -98,28 +98,57 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         currentPath.contains("/oauth/account/social/success") ? .hideLoader : .skip
     }
 
-    /// Schedule a single timeout that hides the SDK loader if the social
-    /// success page is still on-screen after `socialSuccessWatchdogDelay`.
-    /// See `SocialSuccessWatchdogAction` for the no-reload rationale.
+    /// Builds the work item that the social-success watchdog dispatches. Pulled
+    /// out as `internal static` so tests can construct the same item with
+    /// stub callbacks and assert its side effects without standing up a real
+    /// WKWebView or the FronteggAuth singleton.
+    ///
+    /// `pathProvider` is invoked when the item fires (so the test can simulate
+    /// the user navigating away mid-timeout). `onHideLoader` receives the
+    /// only intentional side effect — there is no `onReload` callback because
+    /// reload is never an option (see `SocialSuccessWatchdogAction`).
+    internal static func makeSocialSuccessWatchdogWorkItem(
+        pathProvider: @escaping () -> String?,
+        onHideLoader: @escaping () -> Void,
+        onFire: @escaping () -> Void = {}
+    ) -> DispatchWorkItem {
+        DispatchWorkItem {
+            let currentPath = pathProvider() ?? ""
+            switch socialSuccessWatchdogAction(currentPath: currentPath) {
+            case .skip:
+                return
+            case .hideLoader:
+                onFire()
+                onHideLoader()
+            }
+        }
+    }
+
+    /// Schedule a single timeout. If the user is still on `/social/success`
+    /// when it fires, hide the SDK loader so server-rendered content (the
+    /// server's own loader, the success page, or the social-login-failure
+    /// page) becomes visible. We never reload — that would re-submit the
+    /// already-consumed authorization code and fail an in-flight post-login.
     private func scheduleSocialSuccessWatchdog(for webView: WKWebView, url: URL) {
         socialSuccessWatchdogWorkItem?.cancel()
         socialSuccessWatchdogWorkItem = nil
 
-        let workItem = DispatchWorkItem { [weak self, weak webView] in
-            guard let self = self, let webView = webView else { return }
-            let currentUrl = webView.url ?? url
-
-            switch Self.socialSuccessWatchdogAction(currentPath: currentUrl.path) {
-            case .skip:
-                return
-            case .hideLoader:
-                self.logger.info(
-                    "Social login success page still on-screen after \(self.socialSuccessWatchdogDelay)s; hiding SDK loader so any server-rendered content is visible (no reload — would break in-flight post-login)"
-                )
+        let delay = socialSuccessWatchdogDelay
+        let workItem = Self.makeSocialSuccessWatchdogWorkItem(
+            pathProvider: { [weak webView] in
+                (webView?.url ?? url).path
+            },
+            onHideLoader: { [weak self] in
+                guard let self = self else { return }
                 self.fronteggAuth.setWebLoading(false)
                 self.fronteggAuth.setLoginBoxLoading(false)
+            },
+            onFire: { [weak self] in
+                self?.logger.warning(
+                    "Social login success page still on-screen after \(delay)s; hiding SDK loader so any server-rendered content is visible (no reload — would break in-flight post-login)"
+                )
             }
-        }
+        )
 
         socialSuccessWatchdogWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + socialSuccessWatchdogDelay, execute: workItem)

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -549,14 +549,56 @@ public enum NetworkStatusMonitor {
         }
     }
 
-    private static func routeIsAvailableOnce() async -> Bool {
-        await withCheckedContinuation { cont in
+    /// Bridges a callback-based API that may invoke `resume` more than once into a single
+    /// async result. The first call to `resume` wins; later calls are silently dropped.
+    ///
+    /// This exists because `NWPathMonitor.pathUpdateHandler` is invoked once at start *and* on
+    /// every subsequent path change (Wi-Fi ↔ cellular handoff, VPN reconnect, captive-portal
+    /// auth, sleep/wake). Resuming a `CheckedContinuation` more than once trips
+    /// `_checkedContinuationViolated` and crashes the process with `EXC_BREAKPOINT`. Even
+    /// cancelling the monitor before resuming is not enough: callbacks already enqueued on
+    /// the serial path queue still run after `cancel()`. The lock-guarded boolean here is the
+    /// authoritative gate.
+    private static func awaitFirstBoolResult(
+        body: (@escaping (Bool) -> Void) -> Void
+    ) async -> Bool {
+        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            let lock = NSLock()
+            var didResume = false
+            body { value in
+                let shouldResume: Bool = lock.withLock {
+                    guard !didResume else { return false }
+                    didResume = true
+                    return true
+                }
+                guard shouldResume else { return }
+                cont.resume(returning: value)
+            }
+        }
+    }
+
+    /// One-shot route availability check. Returns `false` if the monitor does not
+    /// deliver a path update within `timeout`. Mirrors `FronteggAuth.checkNetworkPath`'s
+    /// defensive bound — without it, a stalled `NWPathMonitor` (VPN reconnect, MDM
+    /// captive portal) could hang the startup connectivity race indefinitely.
+    private static func routeIsAvailableOnce(timeout: TimeInterval = 1.0) async -> Bool {
+        await awaitFirstBoolResult { resume in
             let m = NWPathMonitor()
             m.pathUpdateHandler = { path in
-                cont.resume(returning: path.status == .satisfied)
+                let satisfied = path.status == .satisfied
+                m.pathUpdateHandler = nil
                 m.cancel()
+                resume(satisfied)
             }
             m.start(queue: pathQueue)
+
+            // Race the monitor against a deadline on the same serial queue so the
+            // cancel + resume are serialized w.r.t. any in-flight path update.
+            pathQueue.asyncAfter(deadline: .now() + timeout) {
+                m.pathUpdateHandler = nil
+                m.cancel()
+                resume(false)
+            }
         }
     }
 }
@@ -630,6 +672,19 @@ extension NetworkStatusMonitor {
 
     static func _testEmitCached(_ value: Bool, forceEmit: Bool = false) {
         updateCached(value, forceEmit: forceEmit)
+    }
+
+    /// Test seam that exposes the one-shot resume primitive used by `routeIsAvailableOnce`.
+    /// Used to verify the `EXC_BREAKPOINT` regression from issue #256 cannot return.
+    static func _testAwaitFirstBoolResult(
+        body: (@escaping (Bool) -> Void) -> Void
+    ) async -> Bool {
+        await awaitFirstBoolResult(body: body)
+    }
+
+    /// Test seam exposing the real `routeIsAvailableOnce` so we can smoke-test the wiring.
+    static func _testRouteIsAvailableOnce() async -> Bool {
+        await routeIsAvailableOnce()
     }
 
     static func _testSnapshot() -> (

--- a/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
+++ b/Sources/FronteggSwift/utils/NetworkStatusMonitor.swift
@@ -584,21 +584,26 @@ public enum NetworkStatusMonitor {
     private static func routeIsAvailableOnce(timeout: TimeInterval = 1.0) async -> Bool {
         await awaitFirstBoolResult { resume in
             let m = NWPathMonitor()
-            m.pathUpdateHandler = { path in
-                let satisfied = path.status == .satisfied
-                m.pathUpdateHandler = nil
-                m.cancel()
-                resume(satisfied)
-            }
-            m.start(queue: pathQueue)
-
-            // Race the monitor against a deadline on the same serial queue so the
-            // cancel + resume are serialized w.r.t. any in-flight path update.
-            pathQueue.asyncAfter(deadline: .now() + timeout) {
+            // Build the deadline work item first so the path handler can cancel it
+            // when an update wins the race — without this, the deadline closure stays
+            // queued, keeps `m` alive until `timeout`, and fires a dropped
+            // cancel + resume(false) after the await has already resumed.
+            let timeoutItem = DispatchWorkItem {
                 m.pathUpdateHandler = nil
                 m.cancel()
                 resume(false)
             }
+            m.pathUpdateHandler = { path in
+                let satisfied = path.status == .satisfied
+                m.pathUpdateHandler = nil
+                m.cancel()
+                timeoutItem.cancel()
+                resume(satisfied)
+            }
+            m.start(queue: pathQueue)
+            // Race the monitor against a deadline on the same serial queue so the
+            // cancel + resume are serialized w.r.t. any in-flight path update.
+            pathQueue.asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
         }
     }
 }

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -352,87 +352,72 @@ final class CustomWebViewTests: XCTestCase {
         XCTAssertNotNil(resolution.providerError)
     }
 
-    // MARK: - Watchdog Retry Counter Logic Tests
+    // MARK: - Social-success watchdog no longer reloads
     //
-    // These tests verify the retry counter logic that was fixed in the
-    // social-success watchdog. The decidePolicyFor handler uses isWatchdogReload
-    // to decide whether to reset socialSuccessRetryCount.
+    // Reloading /oauth/account/social/success while the server is mid-flight
+    // re-submits the already-consumed authorization code. The second
+    // post-login attempt then fails and the server replaces a useful,
+    // specific error (e.g. the HTML below from data-test-id="social-login-
+    // failure-title": "Couldn't sign you in / Cannot resolve user profile,
+    // please check the identity provider configuration") with a generic
+    // message. Post-login can also legitimately exceed the watchdog delay
+    // on a slow tenant. So the watchdog must NEVER reload — it only hides
+    // the SDK loader so whatever the server eventually renders is visible.
+    //
+    // SocialSuccessWatchdogAction is the pure decision returned when the
+    // watchdog fires. It deliberately has no `.reload` case — these tests
+    // pin that contract.
 
-    func test_socialSuccessRetryCount_notResetOnWatchdogReload() {
-        // Simulate the state after first watchdog fires and triggers a reload.
-        var retryCount = 1
-        var isWatchdogReload = true
-
-        // The decidePolicyFor branch for /social/success:
-        // if isWatchdogReload → preserve counter; else → reset to 0
-        if isWatchdogReload {
-            isWatchdogReload = false
-        } else {
-            retryCount = 0
-        }
-
-        XCTAssertEqual(retryCount, 1,
-                       "Retry counter must persist across watchdog-triggered reloads")
-        XCTAssertFalse(isWatchdogReload,
-                       "Flag should be cleared after the reload is processed")
+    func test_socialSuccessWatchdog_hidesLoaderWhenStillOnSocialSuccess() {
+        let action = CustomWebView.socialSuccessWatchdogAction(
+            currentPath: "/fe-auth/oauth/account/social/success"
+        )
+        XCTAssertEqual(action, .hideLoader,
+                       "Still on /social/success after timeout → reveal server-rendered content (loader or error)")
     }
 
-    func test_socialSuccessRetryCount_resetsOnFreshFlow() {
-        // Previous watchdog cycle exhausted, but now a genuinely fresh flow starts.
-        var retryCount = 2
-        var isWatchdogReload = false
-
-        if isWatchdogReload {
-            isWatchdogReload = false
-        } else {
-            retryCount = 0
-        }
-
-        XCTAssertEqual(retryCount, 0,
-                       "Counter must reset on genuinely fresh social login flow")
+    func test_socialSuccessWatchdog_hidesLoaderWhenServerRenderedSocialLoginFailure() {
+        // Even when the page is the actual Frontegg "Couldn't sign you in"
+        // error (data-test-id=social-login-failure-title), the path stays
+        // on /social/success — the action is still hideLoader, NEVER reload.
+        let action = CustomWebView.socialSuccessWatchdogAction(
+            currentPath: "/identity/resources/auth/v2/user/oauth/account/social/success"
+        )
+        XCTAssertEqual(action, .hideLoader,
+                       "Server-rendered social-login-failure page must not trigger a reload — that would re-consume the code")
     }
 
-    func test_socialSuccessRetryCount_exhaustsAfterMaxRetries() {
-        let maxRetries = 2
-        var retryCount = 0
+    func test_socialSuccessWatchdog_skipsAfterNavigationAwayFromSocialSuccess() {
+        XCTAssertEqual(
+            CustomWebView.socialSuccessWatchdogAction(currentPath: "/dashboard"),
+            .skip,
+            "Page navigated to dashboard → watchdog must not interfere"
+        )
+        XCTAssertEqual(
+            CustomWebView.socialSuccessWatchdogAction(currentPath: "/oauth/account/login"),
+            .skip,
+            "Navigated to login page → no watchdog action"
+        )
+        XCTAssertEqual(
+            CustomWebView.socialSuccessWatchdogAction(currentPath: "/postlogin/verify"),
+            .skip,
+            "Navigated to postlogin verify page → no watchdog action"
+        )
+    }
 
-        // Simulate the full watchdog cycle: each retry increments.
-        // On each reload, isWatchdogReload=true prevents reset.
-        for attempt in 1...maxRetries {
-            // Watchdog fires → increment
-            retryCount += 1
-            XCTAssertEqual(retryCount, attempt)
-
-            // Reload triggers /social/success re-navigation with isWatchdogReload=true
-            let isWatchdogReload = true
-            if isWatchdogReload {
-                // Counter preserved — no reset
-            } else {
-                retryCount = 0
+    func test_socialSuccessWatchdog_actionEnumHasNoReloadCase() {
+        // Compile-time guarantee: the enum cases are skip and hideLoader only.
+        // If anyone ever adds .reload, this switch becomes non-exhaustive at
+        // compile time and forces them to update the test (and reconsider why
+        // — see the comment at the top of this section).
+        let cases: [CustomWebView.SocialSuccessWatchdogAction] = [.skip, .hideLoader]
+        for action in cases {
+            switch action {
+            case .skip, .hideLoader:
+                break
             }
         }
-
-        // After max retries, the condition should stop further reloads
-        XCTAssertFalse(retryCount < maxRetries,
-                       "After max retries, watchdog must stop reloading")
-    }
-
-    func test_socialSuccessRetryCount_infiniteLoopWithoutFix() {
-        // Documents the bug: without the isWatchdogReload check,
-        // the counter would reset on every reload, creating an infinite loop.
-        let maxRetries = 2
-        var retryCount = 0
-
-        // Simulate 5 watchdog cycles WITH the old buggy behavior (always reset)
-        for _ in 1...5 {
-            retryCount += 1 // watchdog increments
-            // OLD behavior: always reset on /social/success re-navigation
-            retryCount = 0
-        }
-
-        // Counter never reaches maxRetries — infinite loop
-        XCTAssertTrue(retryCount < maxRetries,
-                      "Without the fix, counter resets every cycle and never exhausts")
+        XCTAssertEqual(cases.count, 2)
     }
 
     // MARK: - Unregistered State Error Type Tests

--- a/Tests/FronteggSwiftTests/CustomWebViewTests.swift
+++ b/Tests/FronteggSwiftTests/CustomWebViewTests.swift
@@ -406,18 +406,65 @@ final class CustomWebViewTests: XCTestCase {
     }
 
     func test_socialSuccessWatchdog_actionEnumHasNoReloadCase() {
-        // Compile-time guarantee: the enum cases are skip and hideLoader only.
-        // If anyone ever adds .reload, this switch becomes non-exhaustive at
-        // compile time and forces them to update the test (and reconsider why
-        // — see the comment at the top of this section).
-        let cases: [CustomWebView.SocialSuccessWatchdogAction] = [.skip, .hideLoader]
-        for action in cases {
+        // Compile-time guarantee: this exhaustive switch (no `default`) stops
+        // building if anyone adds a new case — e.g. `.reload` — forcing them
+        // to update the test and reconsider the no-reload rationale described
+        // at the top of this section.
+        func label(for action: CustomWebView.SocialSuccessWatchdogAction) -> String {
             switch action {
-            case .skip, .hideLoader:
-                break
+            case .skip: return "skip"
+            case .hideLoader: return "hideLoader"
             }
         }
-        XCTAssertEqual(cases.count, 2)
+        XCTAssertEqual(label(for: .skip), "skip")
+        XCTAssertEqual(label(for: .hideLoader), "hideLoader")
+    }
+
+    // MARK: - Watchdog work item — behavioral tests
+    //
+    // These exercise the actual DispatchWorkItem the watchdog dispatches,
+    // built via `makeSocialSuccessWatchdogWorkItem`. They pin two
+    // customer-facing contracts:
+    //   1. On `/social/success`, the timer fires → the loader is hidden.
+    //   2. If the page already navigated away, the timer fires → nothing.
+    // There is no `onReload` callback in the factory — the absence of that
+    // wiring is the no-reload guarantee at the call site (paired with the
+    // enum exhaustiveness test above).
+
+    func test_socialSuccessWatchdogWorkItem_hidesLoaderWhenStillOnSocialSuccess() {
+        var hideCalls = 0
+        var fireCalls = 0
+        let item = CustomWebView.makeSocialSuccessWatchdogWorkItem(
+            pathProvider: { "/fe-auth/oauth/account/social/success" },
+            onHideLoader: { hideCalls += 1 },
+            onFire: { fireCalls += 1 }
+        )
+        item.perform()
+        XCTAssertEqual(hideCalls, 1, "Loader must be hidden when the page is still on /social/success")
+        XCTAssertEqual(fireCalls, 1, "Fire-side-effect (logging) must be called exactly once")
+    }
+
+    func test_socialSuccessWatchdogWorkItem_doesNothingWhenNavigatedAway() {
+        var hideCalls = 0
+        var fireCalls = 0
+        let item = CustomWebView.makeSocialSuccessWatchdogWorkItem(
+            pathProvider: { "/dashboard" },
+            onHideLoader: { hideCalls += 1 },
+            onFire: { fireCalls += 1 }
+        )
+        item.perform()
+        XCTAssertEqual(hideCalls, 0, "Loader must not be touched once the page has left /social/success")
+        XCTAssertEqual(fireCalls, 0, "Fire side effect must not run on the skip path")
+    }
+
+    func test_socialSuccessWatchdogWorkItem_handlesNilPathAsSkip() {
+        var hideCalls = 0
+        let item = CustomWebView.makeSocialSuccessWatchdogWorkItem(
+            pathProvider: { nil },
+            onHideLoader: { hideCalls += 1 }
+        )
+        item.perform()
+        XCTAssertEqual(hideCalls, 0, "A nil current path (deallocated webview) must not trigger the loader-hide")
     }
 
     // MARK: - Unregistered State Error Type Tests

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -276,6 +276,36 @@ final class NetworkStatusMonitorTests: XCTestCase {
         XCTAssertTrue(result, "first resume(true) must win; late resume(false) must be dropped")
     }
 
+    func test_awaitFirstBoolResult_cancellableTimeoutPattern_neverFiresWhenCancelled() async {
+        // Mirrors the production pattern in `routeIsAvailableOnce`: the body schedules a
+        // deadline `DispatchWorkItem` and the "winner" cancels it before its deadline.
+        // The gate alone (covered by the prior test) would still prevent a double-resume
+        // even if the work item ran — this test pins the *cancellation* behavior the
+        // implementation relies on for resource hygiene, so a future edit that removes
+        // `timeoutItem.cancel()` in `routeIsAvailableOnce` regresses a guarded invariant
+        // instead of silently reverting the optimization.
+        let queue = DispatchQueue(label: "test.cancellableTimeoutPattern")
+        let timeoutFired = expectation(description: "deadline work item must not run after cancel")
+        timeoutFired.isInverted = true
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            let timeoutItem = DispatchWorkItem {
+                timeoutFired.fulfill()
+                resume(false)
+            }
+            queue.async {
+                // Simulate the path-update handler winning the race: cancel the deadline
+                // before resuming so the deadline closure never runs.
+                timeoutItem.cancel()
+                resume(true)
+            }
+            queue.asyncAfter(deadline: .now() + 0.05, execute: timeoutItem)
+        }
+        // Wait past the scheduled deadline; the inverted expectation fails if the
+        // cancelled work item ever executes.
+        await fulfillment(of: [timeoutFired], timeout: 0.3)
+        XCTAssertTrue(result, "cancelled deadline must not poison the resumed value")
+    }
+
     func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {
         // Issues many overlapping invocations to maximise the chance of catching a
         // double-resume regression. Each call instantiates its own NWPathMonitor and

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -258,19 +258,22 @@ final class NetworkStatusMonitorTests: XCTestCase {
         // (which also calls `resume(false)` after `timeout` seconds) can never re-enter
         // a continuation that the path update already resumed.
         let queue = DispatchQueue(label: "test.lateSecondFire")
-        let firstFired = expectation(description: "first resume fired")
+        let lateFired = expectation(description: "late resume fired without crashing")
         let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            // First fire immediately on the serial queue — this wins the gate.
             queue.async {
                 resume(true)
-                firstFired.fulfill()
+            }
+            // Second fire arrives later on the same queue, after the await has
+            // already resumed. If the gate ever lets it through, the runtime
+            // will SIGTRAP on the double-resume of the continuation.
+            queue.asyncAfter(deadline: .now() + 0.05) {
+                resume(false)
+                lateFired.fulfill()
             }
         }
-        await fulfillment(of: [firstFired], timeout: 1.0)
-        // Now simulate the timeout closure arriving long after the first resume.
-        // We can't reach the same `resume` sink (it's local to the previous call),
-        // but we exercise the same invariant with a fresh helper invocation that
-        // gets called both immediately and "late" via the queue.
-        XCTAssertTrue(result)
+        await fulfillment(of: [lateFired], timeout: 1.0)
+        XCTAssertTrue(result, "first resume(true) must win; late resume(false) must be dropped")
     }
 
     func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {

--- a/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
+++ b/Tests/FronteggSwiftTests/NetworkStatusMonitorTests.swift
@@ -153,6 +153,158 @@ final class NetworkStatusMonitorTests: XCTestCase {
         XCTAssertFalse(snapshot.hasInitialCheckFired)
     }
 
+    // MARK: - One-shot CheckedContinuation safety (issue #256)
+    //
+    // `NWPathMonitor.pathUpdateHandler` is invoked once at start and again on every
+    // subsequent path change (Wi-Fi ↔ cellular handoff, VPN reconnect, sleep/wake).
+    // The previous `routeIsAvailableOnce()` implementation called
+    // `continuation.resume` directly inside that handler, so a second fire produced
+    // an `EXC_BREAKPOINT` from Swift's `_checkedContinuationViolated` precondition.
+    // These tests pin the new single-resume invariant: even under rapid, sequential,
+    // or massively concurrent re-entries of the callback, the continuation must be
+    // resumed at most once and the host process must not crash.
+    //
+    // The Swift runtime aborts the test process when a CheckedContinuation is resumed
+    // twice, so if any of these regress, the test target will SIGTRAP rather than fail
+    // a single assertion. That's intentional — it's the same signal customers saw.
+
+    func test_awaitFirstBoolResult_singleFire_returnsValue() async {
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            resume(true)
+        }
+        XCTAssertTrue(result)
+    }
+
+    func test_awaitFirstBoolResult_sequentialDoubleFire_doesNotCrash_andReturnsFirstValue() async {
+        // Simulates `NWPathMonitor` firing twice back-to-back on the same serial queue,
+        // which is exactly the case that produced the EXC_BREAKPOINT in production.
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            resume(true)
+            resume(false)
+            resume(true)
+        }
+        XCTAssertTrue(result, "First resume must win; subsequent resumes must be no-ops")
+    }
+
+    func test_awaitFirstBoolResult_asyncDoubleFire_doesNotCrash() async {
+        // Simulates the realistic ordering: handler is delivered on a background serial
+        // queue and fires again later as the path settles (VPN reconnect, captive portal).
+        let queue = DispatchQueue(label: "test.awaitFirstBoolResult.async")
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            queue.async {
+                resume(true)
+                // Even after a brief delay simulating a follow-up path change,
+                // resuming again must not trip the runtime precondition.
+                queue.asyncAfter(deadline: .now() + 0.01) {
+                    resume(false)
+                }
+            }
+        }
+        XCTAssertTrue(result)
+    }
+
+    func test_awaitFirstBoolResult_concurrentFiresFromManyThreads_doesNotCrash() async {
+        // Hammers the gate from multiple threads simultaneously. If the lock-guarded
+        // `didResume` flag ever lets two callers through, the runtime will SIGTRAP.
+        //
+        // We block synchronously inside the continuation body on `group.wait()` so
+        // every one of the 128 dispatched calls has actually been delivered to the
+        // gate before `body` returns. Without this wait, `body` could return (and the
+        // first `resume` could wake the await) before later closures even fire — the
+        // test would pass without genuinely exercising the concurrent re-entry path.
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            let group = DispatchGroup()
+            for index in 0..<128 {
+                group.enter()
+                DispatchQueue.global().async {
+                    // Mix true/false to also assert that "first wins" is the contract,
+                    // not "last wins" or some race-y blend.
+                    resume(index % 2 == 0)
+                    group.leave()
+                }
+            }
+            group.wait()
+        }
+        // Any caller could have been first — only the no-crash invariant matters here.
+        _ = result
+    }
+
+    func test_routeIsAvailableOnce_returnsBoolWithoutCrash() async {
+        // End-to-end smoke test against the real `NWPathMonitor`-backed implementation.
+        // The actual value depends on the test host's network, so we just assert
+        // the call completes — the regression we care about is the crash, not a value.
+        _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+    }
+
+    func test_routeIsAvailableOnce_completesWithinDeadline() async {
+        // Defensive bound: even if `NWPathMonitor` never delivers an update (a real
+        // edge case seen with stalled VPN/MDM profiles and on isolated CI runners),
+        // the call must not hang the caller. The internal timeout is 1s; we allow
+        // a generous 3s envelope to absorb scheduler jitter on slow CI.
+        let start = Date()
+        _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(
+            elapsed,
+            3.0,
+            "routeIsAvailableOnce must not hang when the path monitor is slow or stalled"
+        )
+    }
+
+    func test_awaitFirstBoolResult_lateSecondFireAfterResumeIsHarmless() async {
+        // Models the exact production timing: the first path-update resumes, then a
+        // second update arrives moments later from the same serial queue. The gate
+        // must drop the late call silently so the timeout path in `routeIsAvailableOnce`
+        // (which also calls `resume(false)` after `timeout` seconds) can never re-enter
+        // a continuation that the path update already resumed.
+        let queue = DispatchQueue(label: "test.lateSecondFire")
+        let firstFired = expectation(description: "first resume fired")
+        let result = await NetworkStatusMonitor._testAwaitFirstBoolResult { resume in
+            queue.async {
+                resume(true)
+                firstFired.fulfill()
+            }
+        }
+        await fulfillment(of: [firstFired], timeout: 1.0)
+        // Now simulate the timeout closure arriving long after the first resume.
+        // We can't reach the same `resume` sink (it's local to the previous call),
+        // but we exercise the same invariant with a fresh helper invocation that
+        // gets called both immediately and "late" via the queue.
+        XCTAssertTrue(result)
+    }
+
+    func test_routeIsAvailableOnce_repeatedRapidCalls_doNotCrash() async {
+        // Issues many overlapping invocations to maximise the chance of catching a
+        // double-resume regression. Each call instantiates its own NWPathMonitor and
+        // its own continuation, but they share `pathQueue`, so any serialization
+        // assumptions get exercised here too.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    _ = await NetworkStatusMonitor._testRouteIsAvailableOnce()
+                }
+            }
+        }
+    }
+
+    func test_probeConfiguredReachability_withoutConfiguredBaseURL_doesNotCrash() async {
+        // `probeConfiguredReachability()` falls through to `routeIsAvailableOnce()`
+        // when no base URL is configured. This is the exact call path used by
+        // `FronteggAuth.completeUnauthenticatedStartupInitialization` during the
+        // app-launch connectivity race, which is where customers saw the crash.
+        // The `_testReset()` in `setUp` ensures no base URL is configured.
+        _ = await NetworkStatusMonitor.probeConfiguredReachability()
+    }
+
+    func test_isActive_whenNotMonitoring_doesNotCrash() async {
+        // The 1.2.21 crash signature pointed at `NetworkStatusMonitor.isActive`,
+        // which on master delegates to `probeReachability` → `routeIsAvailableOnce`
+        // when background monitoring is inactive. Cover the same call shape.
+        let snapshot = NetworkStatusMonitor._testSnapshot()
+        XCTAssertFalse(snapshot.monitoringActive, "Sanity: setUp should leave monitoring inactive")
+        _ = await NetworkStatusMonitor.isActive
+    }
+
     @MainActor
     func test_staleMonitoringGeneration_doesNotNotifyHandlersAfterStop() {
         let notCalled = expectation(description: "Stale monitoring generation should not notify")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the embedded social-login watchdog behavior in `CustomWebView`, which affects the post-login navigation/UX and could alter timing-sensitive login flows. Risk is mitigated by added unit tests that pin the new no-reload contract and expected loader behavior.
> 
> **Overview**
> Prevents the embedded social-login “success” watchdog from **reloading** `/oauth/account/social/success` (which could re-consume the auth code and cause generic errors), and instead makes the timeout behavior **only hide the SDK loader** if the WebView is still on that path.
> 
> Refactors the watchdog into testable pure logic (`SocialSuccessWatchdogAction`, `socialSuccessWatchdogAction`, and `makeSocialSuccessWatchdogWorkItem`) and updates tests to assert the no-reload contract and work-item behavior (hide loader vs. skip when navigated away).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c86f3ab9cb6f729880fb7f39d30e0beeedc2423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->