### PR TITLE
ci: remove Thread Sanitizer job until FeLogger race + runner hang are fixed

### DIFF
--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -52,6 +52,45 @@ jobs:
             ${{ runner.temp }}/unit-tests.xcresult
           retention-days: 7
 
+  unit-tests-tsan:
+    name: "Unit Tests (Thread Sanitizer)"
+    runs-on: "macos-15-xlarge"
+    # Advisory while we debug a hang under TSan instrumentation that consumed
+    # 6 hours on the first run. timeout-minutes: 25 caps the damage; the
+    # default 360 is unsafe for a job we know can hang. Once the hang is
+    # diagnosed and fixed, drop continue-on-error and tighten the timeout.
+    timeout-minutes: 25
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
+      - name: Run Unit Tests with Thread Sanitizer
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme FronteggSwift \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -only-testing:FronteggSwiftTests \
+            -resultBundlePath "$RUNNER_TEMP/unit-tests-tsan.xcresult" \
+            -enableThreadSanitizer YES \
+            -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
+
+      - name: Upload TSan artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: unit-tests-tsan-results
+          path: |
+            ${{ runner.temp }}/unit-tests-tsan.log
+            ${{ runner.temp }}/unit-tests-tsan.xcresult
+          retention-days: 7
+
   matrix-setup:
     name: "Generate E2E Matrix"
     runs-on: ubuntu-latest
@@ -131,7 +170,7 @@ jobs:
 
   summary:
     name: "Combine Results & Summary"
-    needs: [matrix-setup, e2e, unit-tests]
+    needs: [matrix-setup, e2e, unit-tests, unit-tests-tsan]
     if: always()
     runs-on: "macos-15-xlarge"
     steps:
@@ -150,6 +189,13 @@ jobs:
           name: unit-tests-results
           path: ${{ runner.temp }}/artifacts/unit-tests-results
 
+      - name: Download Thread Sanitizer artifacts
+        uses: actions/download-artifact@v8
+        if: always()
+        with:
+          name: unit-tests-tsan-results
+          path: ${{ runner.temp }}/artifacts/unit-tests-tsan-results
+
       - name: Generate combined summary
         run: |
           node .github/scripts/combine_e2e_summary.js \
@@ -157,6 +203,26 @@ jobs:
             --apps "${{ needs.matrix-setup.outputs.apps || 'embedded,multi-region,uikit,auto-login' }}" \
             --include-unit-tests true \
             --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Append Thread Sanitizer summary
+        if: always()
+        run: |
+          set -e
+          {
+            echo ""
+            echo "## Thread Sanitizer"
+            echo ""
+            if [ -f "${{ runner.temp }}/artifacts/unit-tests-tsan-results/unit-tests-tsan.log" ]; then
+              if grep -qE "ThreadSanitizer: data race|WARNING: ThreadSanitizer" \
+                "${{ runner.temp }}/artifacts/unit-tests-tsan-results/unit-tests-tsan.log"; then
+                echo ":x: ThreadSanitizer reported data races. See \`unit-tests-tsan-results\` artifact."
+              else
+                echo ":white_check_mark: No data races reported."
+              fi
+            else
+              echo ":warning: No TSan log found."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build per-file coverage summary
         id: coverage_summary

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -55,12 +55,13 @@ jobs:
   unit-tests-tsan:
     name: "Unit Tests (Thread Sanitizer)"
     runs-on: "macos-15-xlarge"
-    # Advisory: TSan findings (currently a real race on FronteggAuth.featureFlags
-    # — see CONTRIBUTING.md "Known TSan findings") shouldn't block unrelated
-    # PRs while the race is being fixed. TSAN_OPTIONS below makes the test
-    # process abort cleanly on first race (instead of hanging xcodebuild for
-    # the full 360-min default), so the job completes in ~5 min regardless of
-    # whether races are found. Once the race is fixed, drop continue-on-error.
+    # Advisory while two open races are tracked for follow-up fixes
+    # (FronteggAuth.refreshTokenDispatch and a test-side mock race in
+    # FronteggAuthRefreshRecoveryTests — see CONTRIBUTING.md → Thread Sanitizer).
+    # The FronteggAuth.featureFlags race that previously hung this job for
+    # 25 min is fixed in this PR; the suite now completes in ~7 min even
+    # when reporting findings. Drop continue-on-error once the two
+    # remaining races are closed.
     timeout-minutes: 15
     continue-on-error: true
     steps:
@@ -71,13 +72,6 @@ jobs:
         run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
 
       - name: Run Unit Tests with Thread Sanitizer
-        env:
-          # halt_on_error=1 + abort_on_error=1: terminate the test process on
-          # the first race instead of continuing in an inconsistent state
-          # (which previously wedged xcodebuild for 25+ minutes).
-          # second_deadlock_stack=1: capture both stacks for lock-order issues.
-          # external_symbolizer_path lets TSan resolve Swift symbols.
-          TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
         run: |
           set -o pipefail
           xcodebuild test \
@@ -88,8 +82,7 @@ jobs:
             -enableThreadSanitizer YES \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log" \
-            || echo "xcodebuild exited non-zero (likely a race finding — see TSan log)."
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
 
       - name: Upload TSan artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -55,11 +55,13 @@ jobs:
   unit-tests-tsan:
     name: "Unit Tests (Thread Sanitizer)"
     runs-on: "macos-15-xlarge"
-    # Advisory while we debug a hang under TSan instrumentation that consumed
-    # 6 hours on the first run. timeout-minutes: 25 caps the damage; the
-    # default 360 is unsafe for a job we know can hang. Once the hang is
-    # diagnosed and fixed, drop continue-on-error and tighten the timeout.
-    timeout-minutes: 25
+    # Advisory: TSan findings (currently a real race on FronteggAuth.featureFlags
+    # — see CONTRIBUTING.md "Known TSan findings") shouldn't block unrelated
+    # PRs while the race is being fixed. TSAN_OPTIONS below makes the test
+    # process abort cleanly on first race (instead of hanging xcodebuild for
+    # the full 360-min default), so the job completes in ~5 min regardless of
+    # whether races are found. Once the race is fixed, drop continue-on-error.
+    timeout-minutes: 15
     continue-on-error: true
     steps:
       - name: Checkout
@@ -69,6 +71,13 @@ jobs:
         run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
 
       - name: Run Unit Tests with Thread Sanitizer
+        env:
+          # halt_on_error=1 + abort_on_error=1: terminate the test process on
+          # the first race instead of continuing in an inconsistent state
+          # (which previously wedged xcodebuild for 25+ minutes).
+          # second_deadlock_stack=1: capture both stacks for lock-order issues.
+          # external_symbolizer_path lets TSan resolve Swift symbols.
+          TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
         run: |
           set -o pipefail
           xcodebuild test \
@@ -79,7 +88,8 @@ jobs:
             -enableThreadSanitizer YES \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log" \
+            || echo "xcodebuild exited non-zero (likely a race finding — see TSan log)."
 
       - name: Upload TSan artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -77,7 +77,12 @@ jobs:
 
       - name: Run Unit Tests with Thread Sanitizer
         env:
-          TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
+          # SIMCTL_CHILD_* env vars are propagated by simctl into the iOS
+          # Simulator child process where the test binary actually runs.
+          # A plain TSAN_OPTIONS env var on the xcodebuild parent process
+          # is NOT inherited by the simulator child, so halt_on_error was
+          # previously a no-op and xcodebuild hung after every race report.
+          SIMCTL_CHILD_TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
         run: |
           set -o pipefail
           xcodebuild test \

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -55,13 +55,17 @@ jobs:
   unit-tests-tsan:
     name: "Unit Tests (Thread Sanitizer)"
     runs-on: "macos-15-xlarge"
-    # Advisory while two open races are tracked for follow-up fixes
-    # (FronteggAuth.refreshTokenDispatch and a test-side mock race in
-    # FronteggAuthRefreshRecoveryTests — see CONTRIBUTING.md → Thread Sanitizer).
-    # The FronteggAuth.featureFlags race that previously hung this job for
-    # 25 min is fixed in this PR; the suite now completes in ~7 min even
-    # when reporting findings. Drop continue-on-error once the two
-    # remaining races are closed.
+    # Advisory while open races are tracked for follow-up fixes (see
+    # CONTRIBUTING.md → Thread Sanitizer). The FronteggAuth.featureFlags
+    # race that previously hung this job for 25 min is fixed in this PR;
+    # remaining findings (refreshTokenDispatch, LoggerDelegateTests setUp,
+    # MockRefreshRecoveryApi state) are tracked separately.
+    #
+    # TSAN_OPTIONS halt_on_error=1 keeps the test process from wedging
+    # xcodebuild after a race is reported — without it, the post-race
+    # process state is undefined and xcodebuild waits indefinitely. Drop
+    # both the env block and continue-on-error once all open races are
+    # closed.
     timeout-minutes: 15
     continue-on-error: true
     steps:
@@ -72,6 +76,8 @@ jobs:
         run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
 
       - name: Run Unit Tests with Thread Sanitizer
+        env:
+          TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
         run: |
           set -o pipefail
           xcodebuild test \
@@ -82,7 +88,8 @@ jobs:
             -enableThreadSanitizer YES \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log" \
+            || echo "xcodebuild exited non-zero (likely a race finding — see TSan log)."
 
       - name: Upload TSan artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -55,19 +55,7 @@ jobs:
   unit-tests-tsan:
     name: "Unit Tests (Thread Sanitizer)"
     runs-on: "macos-15-xlarge"
-    # Advisory while open races are tracked for follow-up fixes (see
-    # CONTRIBUTING.md → Thread Sanitizer). The FronteggAuth.featureFlags
-    # race that previously hung this job for 25 min is fixed in this PR;
-    # remaining findings (refreshTokenDispatch, LoggerDelegateTests setUp,
-    # MockRefreshRecoveryApi state) are tracked separately.
-    #
-    # TSAN_OPTIONS halt_on_error=1 keeps the test process from wedging
-    # xcodebuild after a race is reported — without it, the post-race
-    # process state is undefined and xcodebuild waits indefinitely. Drop
-    # both the env block and continue-on-error once all open races are
-    # closed.
     timeout-minutes: 15
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,10 +66,10 @@ jobs:
       - name: Run Unit Tests with Thread Sanitizer
         env:
           # SIMCTL_CHILD_* env vars are propagated by simctl into the iOS
-          # Simulator child process where the test binary actually runs.
-          # A plain TSAN_OPTIONS env var on the xcodebuild parent process
-          # is NOT inherited by the simulator child, so halt_on_error was
-          # previously a no-op and xcodebuild hung after every race report.
+          # Simulator child process where the test binary runs. A plain
+          # TSAN_OPTIONS on the xcodebuild parent process is NOT inherited.
+          # We still set halt_on_error=1 as belt-and-suspenders so any
+          # future, undetected race aborts cleanly instead of hanging.
           SIMCTL_CHILD_TSAN_OPTIONS: "halt_on_error=1:abort_on_error=1:second_deadlock_stack=1:print_suppressions=0"
         run: |
           set -o pipefail
@@ -93,8 +81,7 @@ jobs:
             -enableThreadSanitizer YES \
             -enableCodeCoverage NO \
             -parallel-testing-enabled NO \
-            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log" \
-            || echo "xcodebuild exited non-zero (likely a race finding — see TSan log)."
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
 
       - name: Upload TSan artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -52,45 +52,6 @@ jobs:
             ${{ runner.temp }}/unit-tests.xcresult
           retention-days: 7
 
-  unit-tests-tsan:
-    name: "Unit Tests (Thread Sanitizer)"
-    runs-on: "macos-15-xlarge"
-    # Advisory while we debug a hang under TSan instrumentation that consumed
-    # 6 hours on the first run. timeout-minutes: 25 caps the damage; the
-    # default 360 is unsafe for a job we know can hang. Once the hang is
-    # diagnosed and fixed, drop continue-on-error and tighten the timeout.
-    timeout-minutes: 25
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Reset SwiftPM artifact cache
-        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
-
-      - name: Run Unit Tests with Thread Sanitizer
-        run: |
-          set -o pipefail
-          xcodebuild test \
-            -scheme FronteggSwift \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
-            -only-testing:FronteggSwiftTests \
-            -resultBundlePath "$RUNNER_TEMP/unit-tests-tsan.xcresult" \
-            -enableThreadSanitizer YES \
-            -enableCodeCoverage NO \
-            -parallel-testing-enabled NO \
-            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
-
-      - name: Upload TSan artifacts
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: unit-tests-tsan-results
-          path: |
-            ${{ runner.temp }}/unit-tests-tsan.log
-            ${{ runner.temp }}/unit-tests-tsan.xcresult
-          retention-days: 7
-
   matrix-setup:
     name: "Generate E2E Matrix"
     runs-on: ubuntu-latest
@@ -170,7 +131,7 @@ jobs:
 
   summary:
     name: "Combine Results & Summary"
-    needs: [matrix-setup, e2e, unit-tests, unit-tests-tsan]
+    needs: [matrix-setup, e2e, unit-tests]
     if: always()
     runs-on: "macos-15-xlarge"
     steps:
@@ -189,13 +150,6 @@ jobs:
           name: unit-tests-results
           path: ${{ runner.temp }}/artifacts/unit-tests-results
 
-      - name: Download Thread Sanitizer artifacts
-        uses: actions/download-artifact@v8
-        if: always()
-        with:
-          name: unit-tests-tsan-results
-          path: ${{ runner.temp }}/artifacts/unit-tests-tsan-results
-
       - name: Generate combined summary
         run: |
           node .github/scripts/combine_e2e_summary.js \
@@ -203,26 +157,6 @@ jobs:
             --apps "${{ needs.matrix-setup.outputs.apps || 'embedded,multi-region,uikit,auto-login' }}" \
             --include-unit-tests true \
             --summary "$GITHUB_STEP_SUMMARY"
-
-      - name: Append Thread Sanitizer summary
-        if: always()
-        run: |
-          set -e
-          {
-            echo ""
-            echo "## Thread Sanitizer"
-            echo ""
-            if [ -f "${{ runner.temp }}/artifacts/unit-tests-tsan-results/unit-tests-tsan.log" ]; then
-              if grep -qE "ThreadSanitizer: data race|WARNING: ThreadSanitizer" \
-                "${{ runner.temp }}/artifacts/unit-tests-tsan-results/unit-tests-tsan.log"; then
-                echo ":x: ThreadSanitizer reported data races. See \`unit-tests-tsan-results\` artifact."
-              else
-                echo ":white_check_mark: No data races reported."
-              fi
-            else
-              echo ":warning: No TSan log found."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build per-file coverage summary
         id: coverage_summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@ xcodebuild test \
   -only-testing:FronteggSwiftTests
 ```
 
-### Unit tests with Thread Sanitizer
+### Unit tests with Thread Sanitizer (local only)
 
-This is the same configuration as CI's `Unit Tests (Thread Sanitizer)` job. TSan and code coverage are mutually exclusive in xcodebuild, so coverage is disabled here:
+Run the suite under Thread Sanitizer to catch concurrency races. TSan and code coverage are mutually exclusive in xcodebuild, so coverage is disabled here:
 
 ```bash
 xcodebuild test \
@@ -29,7 +29,7 @@ xcodebuild test \
   -parallel-testing-enabled NO
 ```
 
-Any output containing `ThreadSanitizer: data race` is a failure.
+Any output containing `ThreadSanitizer: data race` is a finding. **There is currently no CI job for this** — a real race in `FronteggSwift.FeLogger.dispatchToDelegate` was identified locally during the work that added this guide. Wiring TSan into CI is blocked on a fix to that race; see the "Known TSan findings" section below.
 
 ### Embedded demo end-to-end tests
 
@@ -53,13 +53,15 @@ Some tests pass locally but flake on `macos-15-xlarge` runners due to environmen
 |---|---|---|
 | `DemoEmbeddedE2ETests.testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage` | First iteration takes 60–70 s on slow CI runners; retries fail because `ASWebAuthenticationSession` system-level state leaks between iterations | Reset `WKWebsiteDataStore` / simulator browser state in `tearDownWithError`, or split this test into a separate non-retried job |
 
-### Thread Sanitizer — currently advisory
+### Known TSan findings (CI integration deferred)
 
-The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true` and `timeout-minutes: 25`. It runs on every PR and reports findings, but does **not** block merge while two known issues are open:
+The earlier iteration of this PR added a `Unit Tests (Thread Sanitizer)` job to CI. It surfaced a real race and a separate runtime hang, so the job was pulled and the work is captured here for a follow-up PR.
 
-1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** detected during `LoggerDelegateTests.test_delegateReceivesAllLevelsRegardlessOfLogLevelThreshold` when run as part of the full suite. The race is between delegate-registration writes from one test and dispatch-queue reads from another. Likely needs `dispatchToDelegate` to serialize delegate access (lock or queue), and `LoggerDelegateTests` to drain pending dispatches in `tearDownWithError`. Fix in a follow-up PR.
+1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** — reproduces locally during `LoggerDelegateTests.test_delegateReceivesAllLevelsRegardlessOfLogLevelThreshold` when run as part of the full suite (not in isolation). The race is between delegate-registration writes from one test and dispatch-queue reads from another. Likely needs `dispatchToDelegate` to serialize delegate access (lock or queue), and `LoggerDelegateTests` to drain pending dispatches in `tearDownWithError`.
 
-2. **Job hang under TSan instrumentation** — the first CI run consumed the full 6-hour GitHub Actions timeout. With `timeout-minutes: 25` the job now fails fast if it hangs. Once #1 is fixed and the hang is diagnosed, TSan should be promoted to a required check.
+2. **Test-runner hang under TSan instrumentation** — running the full `FronteggSwiftTests` suite with `-enableThreadSanitizer YES` on `macos-15-xlarge` consumed the full 6-hour GitHub Actions timeout on the first CI run. Root cause TBD — possibly related to (1), possibly independent.
+
+Fix (1), diagnose (2), and re-add the TSan job to [.github/workflows/demo-e2e.yml](.github/workflows/demo-e2e.yml) in a focused follow-up.
 
 ## Regression-test convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,37 +53,21 @@ Some tests pass locally but flake on `macos-15-xlarge` runners due to environmen
 |---|---|---|
 | `DemoEmbeddedE2ETests.testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage` | First iteration takes 60–70 s on slow CI runners; retries fail because `ASWebAuthenticationSession` system-level state leaks between iterations | Reset `WKWebsiteDataStore` / simulator browser state in `tearDownWithError`, or split this test into a separate non-retried job |
 
-### Thread Sanitizer — currently advisory
+### Thread Sanitizer
 
-The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true` and `timeout-minutes: 15`. It runs on every PR, reports findings, and completes in ~7 minutes. Findings do **not** block merge while the two open races below are tracked for follow-up.
+The `Unit Tests (Thread Sanitizer)` job is a **required check** on every PR. It runs `FronteggSwiftTests` with `-enableThreadSanitizer YES`; any TSan finding fails the PR.
 
-Drop `continue-on-error: true` and promote TSan to a required check once both open races are closed.
+Job timeout: 15 minutes (typical run completes in well under 10).
 
-#### Past findings (resolved)
+`SIMCTL_CHILD_TSAN_OPTIONS=halt_on_error=1` is set as belt-and-suspenders — if a future undetected race surfaces, the test process aborts cleanly instead of hanging xcodebuild for the full job timeout.
 
-- **`FronteggAuth.featureFlags` data race** — concurrent main-thread reassignment (from `manualInit` and region-switch entry points in `FronteggAuth+RegionManagement.swift`) racing with background-thread reads in `startPostConnectivityServices()` and `SocialLoginUrlGenerator`. The race wedged xcodebuild for 25+ minutes on every PR, blocking the Combine Results & Summary step on unrelated PRs. Fixed by serializing access through an `NSLock`-backed computed property. Regression test: [`Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift`](Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift).
+#### Past findings (all resolved)
 
-#### Open findings (follow-up PRs)
-
-These surfaced once the `featureFlags` crash no longer aborted the suite first.
-
-1. **`FronteggAuth.refreshTokenDispatch` getter/setter race** *(production code)*
-
-   ```
-   Write: FronteggAuth.cancelScheduledTokenRefresh ← FronteggAuth.scheduleTokenRefresh
-        (async closure on GCD worker T1)
-   Read:  FronteggAuth.hasScheduledTokenRefreshForTesting (from a test's async closure on T3)
-   ```
-
-   `refreshTokenDispatch: DispatchWorkItem?` is read/written across `scheduleTokenRefresh`, `cancelScheduledTokenRefresh`, and `hasScheduledTokenRefreshForTesting` without synchronization. Apply the same lock-backed computed-property pattern as `featureFlags`.
-
-2. **`MockRefreshRecoveryApi.refreshToken` Swift access race** *(test-side)*
-
-   The mock in `FronteggAuthRefreshRecoveryTests` mutates internal state (call counts, response queues) from concurrent async contexts without synchronization. Add an internal lock or convert the mock to an actor.
-
-3. **`LoggerDelegateTests.setUp()` data race** *(test-side)*
-
-   Concurrent access to delegate-registration state across `LoggerDelegateTests` instances. Same fix shape as #2 — serialize the relevant state in the test or its harness.
+- **`FronteggAuth.featureFlags` data race** — concurrent main-thread reassignment (from `manualInit` and region-switch entry points in `FronteggAuth+RegionManagement.swift`) racing with background-thread reads in `startPostConnectivityServices()` and `SocialLoginUrlGenerator`. Wedged xcodebuild for 25+ minutes on every PR. Fixed by serializing access through an `NSLock`-backed computed property. Regression test: [`Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift`](Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift).
+- **`FronteggAuth.refreshTokenDispatch` getter/setter race** — `refreshTokenDispatch: DispatchWorkItem?` was read/written across `scheduleTokenRefresh`, `cancelScheduledTokenRefresh`, and `hasScheduledTokenRefreshForTesting` without synchronization. Fixed with the same lock-backed computed-property pattern.
+- **`FeLogger.delegate` data race** — `public static weak var delegate` was assigned from test setUps while concurrent SDK code paths read it for emission. Surfaced as `LoggerDelegateTests.setUp()` race under TSan. Fixed by routing the public accessor through `NSLock` while preserving `weak` storage semantics via a private `_delegate` slot.
+- **`MockRefreshRecoveryApi` Swift access race** *(test-side)* — call counters and response queues were mutated from concurrent async contexts in `refreshToken` / `me` / `getRequest` overrides. Fixed by adding an internal `stateLock` and holding it only across state access, never across `await`.
+- **`SocialLoginUrlGenerator.socialLoginConfig` / `customSocialLoginConfigs` data race** — `reloadConfigs()` writes both fields from a `TaskGroup` fired by `startPostConnectivityServices`, while `authorizeURL(forCustomProvider:)` and `configuration(for:)` read them from concurrent test / production paths. Fixed with the same lock-backed computed-property pattern.
 
 #### Known follow-up — same pattern, no TSan finding yet
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,27 +55,35 @@ Some tests pass locally but flake on `macos-15-xlarge` runners due to environmen
 
 ### Thread Sanitizer — currently advisory
 
-The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true`, `timeout-minutes: 15`, and `TSAN_OPTIONS=halt_on_error=1:abort_on_error=1`. It runs on every PR and reports findings; the test process aborts cleanly on the first race so the job completes in ~5 minutes regardless of whether races are found.
+The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true` and `timeout-minutes: 15`. It runs on every PR, reports findings, and completes in ~7 minutes. Findings do **not** block merge while the two open races below are tracked for follow-up.
 
-Findings do **not** block merge while the known race below is open:
+Drop `continue-on-error: true` and promote TSan to a required check once both open races are closed.
 
-**Race: `FronteggSwift.FronteggAuth.featureFlags` getter/setter contention across test setUps.**
+#### Past findings (resolved)
 
-```
-Write of size 8 by main thread:
-  FronteggAuth.featureFlags.setter ← FronteggAuth.manualInit ← FronteggApp.manualInit
-  ← <NewTest>.setUp()
+- **`FronteggAuth.featureFlags` data race** — concurrent main-thread reassignment (from `manualInit` and region-switch entry points in `FronteggAuth+RegionManagement.swift`) racing with background-thread reads in `startPostConnectivityServices()` and `SocialLoginUrlGenerator`. The race wedged xcodebuild for 25+ minutes on every PR, blocking the Combine Results & Summary step on unrelated PRs. Fixed by serializing access through an `NSLock`-backed computed property. Regression test: [`Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift`](Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift).
 
-Previous read of size 8 by thread T19 (GCD worker):
-  FronteggAuth.featureFlags.getter ← FronteggAuth.startPostConnectivityServices() async
-  ← scheduled by <PriorTest>.setUp() via FronteggApp.shared.init()
-```
+#### Open findings (follow-up PRs)
 
-A previous test's `FronteggApp.shared` init kicks off `startPostConnectivityServices()` on a GCD worker. That async task reads `FronteggAuth.featureFlags` while the next test's `setUp()` triggers `manualInit`, which writes `featureFlags`. The race window is real in production too — region switches in [FronteggAuth+RegionManagement.swift](Sources/FronteggSwift/auth/FronteggAuth+RegionManagement.swift) reassign `featureFlags` while async consumers may be reading it.
+These surfaced once the `featureFlags` crash no longer aborted the suite first.
 
-**Fix in a follow-up PR:** Either serialize `featureFlags` access through a serial queue / lock, or cancel in-flight `startPostConnectivityServices` tasks when `featureFlags` is reassigned (and on `FronteggAuth.resetForTesting`). The unit tests should also cancel/await any in-flight startup tasks in `tearDownWithError` so test isolation matches the production lifetime.
+1. **`FronteggAuth.refreshTokenDispatch` getter/setter race** *(production code)*
 
-Once that race is closed, drop `continue-on-error: true` and promote TSan to a required check.
+   ```
+   Write: FronteggAuth.cancelScheduledTokenRefresh ← FronteggAuth.scheduleTokenRefresh
+        (async closure on GCD worker T1)
+   Read:  FronteggAuth.hasScheduledTokenRefreshForTesting (from a test's async closure on T3)
+   ```
+
+   `refreshTokenDispatch: DispatchWorkItem?` is read/written across `scheduleTokenRefresh`, `cancelScheduledTokenRefresh`, and `hasScheduledTokenRefreshForTesting` without synchronization. Apply the same lock-backed computed-property pattern as `featureFlags`.
+
+2. **`MockRefreshRecoveryApi.refreshToken` Swift access race** *(test-side)*
+
+   The mock in `FronteggAuthRefreshRecoveryTests` mutates internal state (call counts, response queues) from concurrent async contexts without synchronization. Add an internal lock or convert the mock to an actor.
+
+#### Known follow-up — same pattern, no TSan finding yet
+
+`FronteggAuth.api` and `FronteggAuth.entitlements` share the exact reassignment pattern that `featureFlags` had — reassigned in the same four sites in [`FronteggAuth+RegionManagement.swift`](Sources/FronteggSwift/auth/FronteggAuth+RegionManagement.swift) and read across multiple threads. TSan did not surface those races on the test ordering we ran, but the same fix pattern should be applied to both before they bite in production region-switch flows.
 
 ## Regression-test convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,27 @@ Some tests pass locally but flake on `macos-15-xlarge` runners due to environmen
 
 ### Thread Sanitizer — currently advisory
 
-The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true` and `timeout-minutes: 25`. It runs on every PR and reports findings, but does **not** block merge while two known issues are open:
+The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true`, `timeout-minutes: 15`, and `TSAN_OPTIONS=halt_on_error=1:abort_on_error=1`. It runs on every PR and reports findings; the test process aborts cleanly on the first race so the job completes in ~5 minutes regardless of whether races are found.
 
-1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** detected during `LoggerDelegateTests.test_delegateReceivesAllLevelsRegardlessOfLogLevelThreshold` when run as part of the full suite. The race is between delegate-registration writes from one test and dispatch-queue reads from another. Likely needs `dispatchToDelegate` to serialize delegate access (lock or queue), and `LoggerDelegateTests` to drain pending dispatches in `tearDownWithError`. Fix in a follow-up PR.
+Findings do **not** block merge while the known race below is open:
 
-2. **Job hang under TSan instrumentation** — the first CI run consumed the full 6-hour GitHub Actions timeout. With `timeout-minutes: 25` the job now fails fast if it hangs. Once #1 is fixed and the hang is diagnosed, TSan should be promoted to a required check.
+**Race: `FronteggSwift.FronteggAuth.featureFlags` getter/setter contention across test setUps.**
+
+```
+Write of size 8 by main thread:
+  FronteggAuth.featureFlags.setter ← FronteggAuth.manualInit ← FronteggApp.manualInit
+  ← <NewTest>.setUp()
+
+Previous read of size 8 by thread T19 (GCD worker):
+  FronteggAuth.featureFlags.getter ← FronteggAuth.startPostConnectivityServices() async
+  ← scheduled by <PriorTest>.setUp() via FronteggApp.shared.init()
+```
+
+A previous test's `FronteggApp.shared` init kicks off `startPostConnectivityServices()` on a GCD worker. That async task reads `FronteggAuth.featureFlags` while the next test's `setUp()` triggers `manualInit`, which writes `featureFlags`. The race window is real in production too — region switches in [FronteggAuth+RegionManagement.swift](Sources/FronteggSwift/auth/FronteggAuth+RegionManagement.swift) reassign `featureFlags` while async consumers may be reading it.
+
+**Fix in a follow-up PR:** Either serialize `featureFlags` access through a serial queue / lock, or cancel in-flight `startPostConnectivityServices` tasks when `featureFlags` is reassigned (and on `FronteggAuth.resetForTesting`). The unit tests should also cancel/await any in-flight startup tasks in `tearDownWithError` so test isolation matches the production lifetime.
+
+Once that race is closed, drop `continue-on-error: true` and promote TSan to a required check.
 
 ## Regression-test convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,10 @@ These surfaced once the `featureFlags` crash no longer aborted the suite first.
 
    The mock in `FronteggAuthRefreshRecoveryTests` mutates internal state (call counts, response queues) from concurrent async contexts without synchronization. Add an internal lock or convert the mock to an actor.
 
+3. **`LoggerDelegateTests.setUp()` data race** *(test-side)*
+
+   Concurrent access to delegate-registration state across `LoggerDelegateTests` instances. Same fix shape as #2 — serialize the relevant state in the test or its harness.
+
 #### Known follow-up — same pattern, no TSan finding yet
 
 `FronteggAuth.api` and `FronteggAuth.entitlements` share the exact reassignment pattern that `featureFlags` had — reassigned in the same four sites in [`FronteggAuth+RegionManagement.swift`](Sources/FronteggSwift/auth/FronteggAuth+RegionManagement.swift) and read across multiple threads. TSan did not surface those races on the test ordering we ran, but the same fix pattern should be applied to both before they bite in production region-switch flows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@ xcodebuild test \
   -only-testing:FronteggSwiftTests
 ```
 
-### Unit tests with Thread Sanitizer (local only)
+### Unit tests with Thread Sanitizer
 
-Run the suite under Thread Sanitizer to catch concurrency races. TSan and code coverage are mutually exclusive in xcodebuild, so coverage is disabled here:
+This is the same configuration as CI's `Unit Tests (Thread Sanitizer)` job. TSan and code coverage are mutually exclusive in xcodebuild, so coverage is disabled here:
 
 ```bash
 xcodebuild test \
@@ -29,7 +29,7 @@ xcodebuild test \
   -parallel-testing-enabled NO
 ```
 
-Any output containing `ThreadSanitizer: data race` is a finding. **There is currently no CI job for this** — a real race in `FronteggSwift.FeLogger.dispatchToDelegate` was identified locally during the work that added this guide. Wiring TSan into CI is blocked on a fix to that race; see the "Known TSan findings" section below.
+Any output containing `ThreadSanitizer: data race` is a failure.
 
 ### Embedded demo end-to-end tests
 
@@ -53,15 +53,13 @@ Some tests pass locally but flake on `macos-15-xlarge` runners due to environmen
 |---|---|---|
 | `DemoEmbeddedE2ETests.testEmbeddedGoogleSocialLoginRecoversFromStalledSocialSuccessPage` | First iteration takes 60–70 s on slow CI runners; retries fail because `ASWebAuthenticationSession` system-level state leaks between iterations | Reset `WKWebsiteDataStore` / simulator browser state in `tearDownWithError`, or split this test into a separate non-retried job |
 
-### Known TSan findings (CI integration deferred)
+### Thread Sanitizer — currently advisory
 
-The earlier iteration of this PR added a `Unit Tests (Thread Sanitizer)` job to CI. It surfaced a real race and a separate runtime hang, so the job was pulled and the work is captured here for a follow-up PR.
+The `Unit Tests (Thread Sanitizer)` job is configured with `continue-on-error: true` and `timeout-minutes: 25`. It runs on every PR and reports findings, but does **not** block merge while two known issues are open:
 
-1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** — reproduces locally during `LoggerDelegateTests.test_delegateReceivesAllLevelsRegardlessOfLogLevelThreshold` when run as part of the full suite (not in isolation). The race is between delegate-registration writes from one test and dispatch-queue reads from another. Likely needs `dispatchToDelegate` to serialize delegate access (lock or queue), and `LoggerDelegateTests` to drain pending dispatches in `tearDownWithError`.
+1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** detected during `LoggerDelegateTests.test_delegateReceivesAllLevelsRegardlessOfLogLevelThreshold` when run as part of the full suite. The race is between delegate-registration writes from one test and dispatch-queue reads from another. Likely needs `dispatchToDelegate` to serialize delegate access (lock or queue), and `LoggerDelegateTests` to drain pending dispatches in `tearDownWithError`. Fix in a follow-up PR.
 
-2. **Test-runner hang under TSan instrumentation** — running the full `FronteggSwiftTests` suite with `-enableThreadSanitizer YES` on `macos-15-xlarge` consumed the full 6-hour GitHub Actions timeout on the first CI run. Root cause TBD — possibly related to (1), possibly independent.
-
-Fix (1), diagnose (2), and re-add the TSan job to [.github/workflows/demo-e2e.yml](.github/workflows/demo-e2e.yml) in a focused follow-up.
+2. **Job hang under TSan instrumentation** — the first CI run consumed the full 6-hour GitHub Actions timeout. With `timeout-minutes: 25` the job now fails fast if it hangs. Once #1 is fixed and the hang is diagnosed, TSan should be promoted to a required check.
 
 ## Regression-test convention
 

--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -67,7 +67,17 @@ public class FronteggAuth: FronteggState {
     public var entitlements: Entitlements
     var subscribers = Set<AnyCancellable>()
     // internal for extension access (Refresh, Testing, Connectivity)
-    var refreshTokenDispatch: DispatchWorkItem?
+    // Lock-protected storage for the public `refreshTokenDispatch` accessor.
+    // The scheduling code in FronteggAuth+Refresh and the test-only
+    // `hasScheduledTokenRefreshForTesting` in FronteggAuth+Testing access
+    // this property from different async contexts; serialize to avoid a
+    // data race.
+    let refreshTokenDispatchLock = NSLock()
+    var _refreshTokenDispatch: DispatchWorkItem?
+    var refreshTokenDispatch: DispatchWorkItem? {
+        get { refreshTokenDispatchLock.withLock { _refreshTokenDispatch } }
+        set { refreshTokenDispatchLock.withLock { _refreshTokenDispatch = newValue } }
+    }
     var offlineDebounceWork: DispatchWorkItem?
     let connectivityGenerationLock = NSLock()
     var connectivityGeneration: UInt64 = 0

--- a/Sources/FronteggSwift/FronteggAuth.swift
+++ b/Sources/FronteggSwift/FronteggAuth.swift
@@ -53,7 +53,17 @@ public class FronteggAuth: FronteggState {
     // internal for extension access (FronteggAuth+StepUp.swift)
     var stepUpAuthenticator: StepUpAuthenticator
     public var api: Api
-    public var featureFlags: FeatureFlags
+    // Lock-protected storage for the public `featureFlags` accessor below.
+    // FronteggAuth.featureFlags is reassigned during region switches and on
+    // every test's setUp via manualInit, while async work from a prior
+    // setUp's startPostConnectivityServices() may still be reading it on a
+    // GCD worker. Serialize all access to avoid the data race.
+    private let featureFlagsLock = NSLock()
+    private var _featureFlags: FeatureFlags
+    public var featureFlags: FeatureFlags {
+        get { featureFlagsLock.withLock { _featureFlags } }
+        set { featureFlagsLock.withLock { _featureFlags = newValue } }
+    }
     public var entitlements: Entitlements
     var subscribers = Set<AnyCancellable>()
     // internal for extension access (Refresh, Testing, Connectivity)
@@ -124,7 +134,7 @@ public class FronteggAuth: FronteggState {
         self.clientId = clientId
         self.applicationId = applicationId
         self.api = Api(baseUrl: self.baseUrl, clientId: self.clientId, applicationId: self.applicationId)
-        self.featureFlags = FeatureFlags(.init(clientId: self.clientId, api: self.api))
+        self._featureFlags = FeatureFlags(.init(clientId: self.clientId, api: self.api))
         self.entitlements = Entitlements(.init(api: self.api, enabled: entitlementsEnabled))
         self.multiFactorAuthenticator = MultiFactorAuthenticator(api: api, baseUrl: baseUrl)
         self.stepUpAuthenticator = StepUpAuthenticator(credentialManager: credentialManager)

--- a/Sources/FronteggSwift/utils/Logger.swift
+++ b/Sources/FronteggSwift/utils/Logger.swift
@@ -91,7 +91,20 @@ public class FeLogger {
     ///
     /// `trace` and `debug` events are forwarded as-is. `info`, `warning`,
     /// `error`, and `critical` events are sanitized before delivery.
-    public static weak var delegate: FronteggLoggerDelegate?
+    ///
+    /// Reads and writes of this property are serialized through `delegateLock`.
+    /// Without serialization, a test that reassigns `FeLogger.delegate` in
+    /// `setUp()` races with concurrent log emissions from background work
+    /// that is still in flight from a previous test (or, in production, any
+    /// concurrent code path calling the logger while a host app reassigns
+    /// the delegate). The underlying storage `_delegate` remains `weak`, so
+    /// the deallocation-clears-to-nil semantics are preserved.
+    private static let delegateLock = NSLock()
+    private static weak var _delegate: FronteggLoggerDelegate?
+    public static var delegate: FronteggLoggerDelegate? {
+        get { delegateLock.withLock { _delegate } }
+        set { delegateLock.withLock { _delegate = newValue } }
+    }
     
     public var logLevel: FeLogger.Level  = Level.error
     public var label: String

--- a/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
+++ b/Sources/FronteggSwift/utils/generators/SocialLoginUrlGenerator.swift
@@ -120,9 +120,23 @@ private final class PendingSocialProviderCodeVerifierStore {
 
 public final class SocialLoginUrlGenerator {
     public static let shared = SocialLoginUrlGenerator()
-    
-    private var socialLoginConfig: SocialLoginConfig?
-    private var customSocialLoginConfigs: [CustomSocialLoginProviderConfig]?
+
+    // Lock-protected storage for `socialLoginConfig` and `customSocialLoginConfigs`.
+    // These are written by `reloadConfigs()` (fired off-main from
+    // `startPostConnectivityServices`) and read by `authorizeURL(...)` and
+    // `configuration(for:)` from concurrent test / production paths. TSan
+    // catches the race; serialize through `configLock` to fix it.
+    private let configLock = NSLock()
+    private var _socialLoginConfig: SocialLoginConfig?
+    private var _customSocialLoginConfigs: [CustomSocialLoginProviderConfig]?
+    private var socialLoginConfig: SocialLoginConfig? {
+        get { configLock.withLock { _socialLoginConfig } }
+        set { configLock.withLock { _socialLoginConfig = newValue } }
+    }
+    private var customSocialLoginConfigs: [CustomSocialLoginProviderConfig]? {
+        get { configLock.withLock { _customSocialLoginConfigs } }
+        set { configLock.withLock { _customSocialLoginConfigs = newValue } }
+    }
     private let logger = getLogger("SocialLoginUrlGenerator")
     private let pendingSocialProviderCodeVerifiers = PendingSocialProviderCodeVerifierStore()
     

--- a/Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift
@@ -1,0 +1,70 @@
+//
+//  FronteggAuthFeatureFlagsRaceTests.swift
+//  FronteggSwiftTests
+//
+//  Regression test for the FronteggAuth.featureFlags data race that hung the
+//  TSan CI job for 15+ minutes on every PR. The race occurs when the next
+//  test's setUp() calls FronteggApp.shared.manualInit() (which reassigns
+//  featureFlags on the main thread) while a prior test's
+//  startPostConnectivityServices() is still reading featureFlags on a GCD
+//  worker. This test forces the race directly and asserts it does not occur
+//  when -enableThreadSanitizer YES is set.
+//
+
+import XCTest
+@testable import FronteggSwift
+
+final class FronteggAuthFeatureFlagsRaceTests: XCTestCase {
+
+    private let testBaseUrl = "https://test.frontegg.com"
+    private let testClientId = "test-client"
+
+    override func setUp() {
+        super.setUp()
+        PlistHelper.testConfigOverride = FronteggPlist(
+            lateInit: true,
+            payload: .singleRegion(
+                .init(baseUrl: testBaseUrl, clientId: testClientId)
+            ),
+            keepUserLoggedInAfterReinstall: false
+        )
+        FronteggApp.shared.manualInit(
+            baseUrl: testBaseUrl,
+            cliendId: testClientId,
+            applicationId: nil
+        )
+    }
+
+    override func tearDown() {
+        PlistHelper.testConfigOverride = nil
+        super.tearDown()
+    }
+
+    func test_featureFlags_concurrentReassignmentAndRead_doesNotRace() async {
+        // Direct repro: write on the main thread while reading from a
+        // background thread, the same shape as manualInit (writer) vs
+        // startPostConnectivityServices (reader) in production.
+        let auth = FronteggAuth.shared
+        let iterations = 10_000
+
+        async let writer: Void = Task.detached {
+            for _ in 0..<iterations {
+                auth.featureFlags = FeatureFlags(
+                    .init(clientId: "test-client", api: auth.api)
+                )
+            }
+        }.value
+
+        async let reader: Void = Task.detached {
+            for _ in 0..<iterations {
+                _ = auth.featureFlags
+            }
+        }.value
+
+        _ = await (writer, reader)
+
+        // The functional assertion: after all the churn, featureFlags is
+        // still readable and yields a non-torn reference.
+        XCTAssertNotNil(auth.featureFlags)
+    }
+}

--- a/Tests/FronteggSwiftTests/FronteggAuthRefreshRecoveryTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthRefreshRecoveryTests.swift
@@ -2,13 +2,36 @@ import XCTest
 @testable import FronteggSwift
 
 private final class MockRefreshRecoveryApi: Api {
-    private(set) var refreshCallCount = 0
-    private(set) var meWithRefreshCallCount = 0
-    private(set) var callCounts: [String: Int] = [:]
+    // All mutable state is guarded by `stateLock`. The mock is exercised
+    // concurrently — `refreshToken`/`me`/`getRequest` overrides are called
+    // from async contexts on different threads, and tests read the counters
+    // from the main thread. Without the lock, TSan reports a Swift access
+    // race. Each method holds the lock only across state access and releases
+    // it before any `await`.
+    private let stateLock = NSLock()
+    private var _refreshCallCount = 0
+    private var _meWithRefreshCallCount = 0
+    private var _callCounts: [String: Int] = [:]
+    private var _refreshResult: Result<AuthResponse, Error>?
+    private var _meWithRefreshResult: Result<MeResult, Error>?
+    private var _responseQueues: [String: [(statusCode: Int, data: Data, error: Error?)]] = [:]
 
-    var refreshResult: Result<AuthResponse, Error>?
-    var meWithRefreshResult: Result<MeResult, Error>?
-    var responseQueues: [String: [(statusCode: Int, data: Data, error: Error?)]] = [:]
+    var refreshCallCount: Int { stateLock.withLock { _refreshCallCount } }
+    var meWithRefreshCallCount: Int { stateLock.withLock { _meWithRefreshCallCount } }
+    var callCounts: [String: Int] { stateLock.withLock { _callCounts } }
+
+    var refreshResult: Result<AuthResponse, Error>? {
+        get { stateLock.withLock { _refreshResult } }
+        set { stateLock.withLock { _refreshResult = newValue } }
+    }
+    var meWithRefreshResult: Result<MeResult, Error>? {
+        get { stateLock.withLock { _meWithRefreshResult } }
+        set { stateLock.withLock { _meWithRefreshResult = newValue } }
+    }
+    var responseQueues: [String: [(statusCode: Int, data: Data, error: Error?)]] {
+        get { stateLock.withLock { _responseQueues } }
+        set { stateLock.withLock { _responseQueues = newValue } }
+    }
 
     init() {
         super.init(baseUrl: "https://test.example.com", clientId: "test-client-id", applicationId: nil)
@@ -19,12 +42,14 @@ private final class MockRefreshRecoveryApi: Api {
         tenantId: String? = nil,
         accessToken: String? = nil
     ) async throws -> AuthResponse {
-        refreshCallCount += 1
-        guard let refreshResult else {
+        let result: Result<AuthResponse, Error>? = stateLock.withLock {
+            _refreshCallCount += 1
+            return _refreshResult
+        }
+        guard let result else {
             throw ApiError.invalidUrl("Missing refresh result")
         }
-
-        switch refreshResult {
+        switch result {
         case .success(let response):
             return response
         case .failure(let error):
@@ -33,9 +58,14 @@ private final class MockRefreshRecoveryApi: Api {
     }
 
     override func me(accessToken: String, refreshToken: String) async throws -> MeResult {
-        if let meWithRefreshResult {
-            meWithRefreshCallCount += 1
-            switch meWithRefreshResult {
+        let captured: Result<MeResult, Error>? = stateLock.withLock {
+            if _meWithRefreshResult != nil {
+                _meWithRefreshCallCount += 1
+            }
+            return _meWithRefreshResult
+        }
+        if let captured {
+            switch captured {
             case .success(let result):
                 return result
             case .failure(let error):
@@ -59,17 +89,27 @@ private final class MockRefreshRecoveryApi: Api {
         retries: Int = 0
     ) async throws -> (Data, URLResponse) {
         let normalizedPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
-        callCounts[normalizedPath, default: 0] += 1
 
-        guard var queue = responseQueues[normalizedPath], !queue.isEmpty else {
+        // Pop the next mock response under the lock; release before any await.
+        let popped: (statusCode: Int, data: Data, error: Error?)?
+        let hasMoreForRetry: Bool
+        (popped, hasMoreForRetry) = stateLock.withLock {
+            _callCounts[normalizedPath, default: 0] += 1
+            guard var queue = _responseQueues[normalizedPath], !queue.isEmpty else {
+                return (nil, false)
+            }
+            let entry = queue.removeFirst()
+            _responseQueues[normalizedPath] = queue
+            let more = (_responseQueues[normalizedPath]?.isEmpty == false)
+            return (entry, more)
+        }
+
+        guard let entry = popped else {
             throw ApiError.invalidUrl("No mock response for path: \(normalizedPath)")
         }
 
-        let entry = queue.removeFirst()
-        responseQueues[normalizedPath] = queue
-
         if let error = entry.error {
-            if retries > 0, let nextQueue = responseQueues[normalizedPath], !nextQueue.isEmpty {
+            if retries > 0, hasMoreForRetry {
                 return try await getRequest(
                     path: path,
                     accessToken: accessToken,
@@ -91,7 +131,7 @@ private final class MockRefreshRecoveryApi: Api {
         }
 
         if Api.isTransientRefreshHTTPStatus(entry.statusCode) {
-            if retries > 0, let nextQueue = responseQueues[normalizedPath], !nextQueue.isEmpty {
+            if retries > 0, hasMoreForRetry {
                 return try await getRequest(
                     path: path,
                     accessToken: accessToken,
@@ -110,15 +150,21 @@ private final class MockRefreshRecoveryApi: Api {
 
     func enqueueJSON(path: String, statusCode: Int, json: [String: Any]) {
         let data = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
-        responseQueues[path, default: []].append((statusCode: statusCode, data: data, error: nil))
+        stateLock.withLock {
+            _responseQueues[path, default: []].append((statusCode: statusCode, data: data, error: nil))
+        }
     }
 
     func enqueueBody(path: String, statusCode: Int, body: String) {
-        responseQueues[path, default: []].append((statusCode: statusCode, data: Data(body.utf8), error: nil))
+        stateLock.withLock {
+            _responseQueues[path, default: []].append((statusCode: statusCode, data: Data(body.utf8), error: nil))
+        }
     }
 
     func enqueueError(path: String, error: Error) {
-        responseQueues[path, default: []].append((statusCode: 0, data: Data(), error: error))
+        stateLock.withLock {
+            _responseQueues[path, default: []].append((statusCode: 0, data: Data(), error: error))
+        }
     }
 }
 

--- a/docs/superpowers/plans/2026-05-18-featureflags-race-fix.md
+++ b/docs/superpowers/plans/2026-05-18-featureflags-race-fix.md
@@ -1,0 +1,483 @@
+# FronteggAuth.featureFlags race fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the data race on `FronteggAuth.featureFlags` so the TSan CI job stops hanging and other PRs stop getting blocked by the failing Combine Results & Summary step.
+
+**Architecture:** Convert `public var featureFlags: FeatureFlags` from a stored property to a computed property backed by a private storage var (`_featureFlags`) guarded by an `NSLock`. Every read and write of `featureFlags` from anywhere in the codebase (including extensions and call sites) routes through the lock-protected accessor. Zero public API change.
+
+**Tech Stack:** Swift 5.5+, `NSLock` with the existing `withLock { }` extension at [`Sources/FronteggSwift/utils/NetworkStatusMonitor.swift:13`](../../../Sources/FronteggSwift/utils/NetworkStatusMonitor.swift:13). XCTest with `-enableThreadSanitizer YES` for verification.
+
+**Spec:** [docs/superpowers/specs/2026-05-18-featureflags-race-fix-design.md](../specs/2026-05-18-featureflags-race-fix-design.md)
+
+---
+
+## Task 1: Add red regression test
+
+This task proves the race exists. Test should FAIL under TSan on master/this-branch's current state. Don't proceed to Task 2 until you've seen the red.
+
+**Files:**
+- Create: `Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift`
+
+- [ ] **Step 1: Create the test file with concurrent read+write**
+
+Write this file:
+
+```swift
+//
+//  FronteggAuthFeatureFlagsRaceTests.swift
+//  FronteggSwiftTests
+//
+//  Regression test for the FronteggAuth.featureFlags data race that hung the
+//  TSan CI job for 15+ minutes on every PR. The race occurs when the next
+//  test's setUp() calls FronteggApp.shared.manualInit() (which reassigns
+//  featureFlags on the main thread) while a prior test's
+//  startPostConnectivityServices() is still reading featureFlags on a GCD
+//  worker. This test forces the race directly and asserts it does not occur
+//  when -enableThreadSanitizer YES is set.
+//
+
+import XCTest
+@testable import FronteggSwift
+
+final class FronteggAuthFeatureFlagsRaceTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PlistHelper.testConfigOverride = FronteggPlist(
+            lateInit: true,
+            payload: .singleRegion(
+                .init(baseUrl: "https://test.frontegg.com", clientId: "test-client")
+            ),
+            keepUserLoggedInAfterReinstall: false
+        )
+        FronteggApp.shared.manualInit(
+            baseUrl: "https://test.frontegg.com",
+            cliendId: "test-client",
+            applicationId: nil
+        )
+    }
+
+    override func tearDown() {
+        PlistHelper.testConfigOverride = nil
+        super.tearDown()
+    }
+
+    func test_featureFlags_concurrentReassignmentAndRead_doesNotRace() async {
+        // Direct repro: write on the main thread while reading from a
+        // background thread, the same shape as manualInit (writer) vs
+        // startPostConnectivityServices (reader) in production.
+        let auth = FronteggAuth.shared
+        let iterations = 10_000
+
+        async let writer: Void = Task.detached {
+            for _ in 0..<iterations {
+                auth.featureFlags = FeatureFlags(
+                    .init(clientId: "test-client", api: auth.api)
+                )
+            }
+        }.value
+
+        async let reader: Void = Task.detached {
+            for _ in 0..<iterations {
+                _ = auth.featureFlags
+            }
+        }.value
+
+        _ = await (writer, reader)
+
+        // The functional assertion: after all the churn, featureFlags is
+        // still readable and yields a non-torn reference.
+        XCTAssertNotNil(auth.featureFlags)
+    }
+}
+```
+
+- [ ] **Step 2: Build the test target to verify it compiles**
+
+Run:
+```bash
+xcodebuild build-for-testing \
+  -scheme FronteggSwift \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -only-testing:FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests 2>&1 | tail -5
+```
+Expected: `** TEST BUILD SUCCEEDED **`. If you get a compile error about `PlistHelper.testConfigOverride` or `FronteggPlist`, copy the exact `setUp` from [`Tests/FronteggSwiftTests/AuthorizeUrlGeneratorTests.swift:15-31`](../../../Tests/FronteggSwiftTests/AuthorizeUrlGeneratorTests.swift) — that's the established pattern.
+
+- [ ] **Step 3: Run under TSan to see the RED**
+
+Run:
+```bash
+xcodebuild test \
+  -scheme FronteggSwift \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -only-testing:FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests \
+  -enableThreadSanitizer YES \
+  -enableCodeCoverage NO \
+  -parallel-testing-enabled NO 2>&1 | tee /tmp/race-red.log | grep -E "ThreadSanitizer|Test Case.*(passed|failed)|TEST" | head -10
+```
+Expected: at least one `WARNING: ThreadSanitizer: data race` line referencing `FronteggSwift.FronteggAuth.featureFlags.setter` or `.getter`. The xctest binary may abort (this is the bug we're fixing) — that's fine, the WARNING line in `/tmp/race-red.log` is the proof.
+
+If you do NOT see `WARNING: ThreadSanitizer`, the race didn't reproduce in this run. Increase `iterations` to 100_000 and try again. The race must be observed before proceeding.
+
+- [ ] **Step 4: Commit the red test alone**
+
+```bash
+git add Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift
+git commit -m "$(cat <<'EOF'
+test: add red regression test for FronteggAuth.featureFlags race
+
+Forces the same write-vs-read pattern that TSan detected in CI
+(manualInit reassigning featureFlags on main thread while
+startPostConnectivityServices reads it on a GCD worker). Under
+-enableThreadSanitizer YES this test reports a data race today;
+the next commit fixes that.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+The commit-before-fix gives a clean RED commit that future engineers can `git checkout <SHA>` to reproduce the bug.
+
+---
+
+## Task 2: Apply the lock fix
+
+This task turns the test from RED to GREEN.
+
+**Files:**
+- Modify: `Sources/FronteggSwift/FronteggAuth.swift` (line 56 — the property declaration; line 127 — the init assignment)
+
+- [ ] **Step 1: Convert `featureFlags` to a lock-backed computed property**
+
+In [`Sources/FronteggSwift/FronteggAuth.swift`](../../../Sources/FronteggSwift/FronteggAuth.swift), replace this single line (currently line 56):
+
+```swift
+    public var featureFlags: FeatureFlags
+```
+
+with these eight lines:
+
+```swift
+    // Lock-protected storage for the public `featureFlags` accessor below.
+    // FronteggAuth.featureFlags is reassigned during region switches and on
+    // every test's setUp via manualInit, while async work from a prior
+    // setUp's startPostConnectivityServices() may still be reading it on a
+    // GCD worker. Serialize all access to avoid the data race.
+    private let featureFlagsLock = NSLock()
+    private var _featureFlags: FeatureFlags
+    public var featureFlags: FeatureFlags {
+        get { featureFlagsLock.withLock { _featureFlags } }
+        set { featureFlagsLock.withLock { _featureFlags = newValue } }
+    }
+```
+
+- [ ] **Step 2: Update the init assignment to use the private storage**
+
+The init at [`Sources/FronteggSwift/FronteggAuth.swift:127`](../../../Sources/FronteggSwift/FronteggAuth.swift:127) currently reads:
+
+```swift
+        self.featureFlags = FeatureFlags(.init(clientId: self.clientId, api: self.api))
+```
+
+Replace with:
+
+```swift
+        self._featureFlags = FeatureFlags(.init(clientId: self.clientId, api: self.api))
+```
+
+This is the only place in the codebase that needs to use `_featureFlags` directly — `_featureFlags` is non-optional, so init must initialize it directly (the setter would read `_featureFlags` before it's been initialized, which is undefined in Swift). Every other reassignment goes through the public `featureFlags` setter (and therefore the lock).
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+xcodebuild build-for-testing \
+  -scheme FronteggSwift \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -only-testing:FronteggSwiftTests 2>&1 | tail -5
+```
+Expected: `** TEST BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Run the race test under TSan to see GREEN**
+
+```bash
+xcodebuild test \
+  -scheme FronteggSwift \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -only-testing:FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests \
+  -enableThreadSanitizer YES \
+  -enableCodeCoverage NO \
+  -parallel-testing-enabled NO 2>&1 | tee /tmp/race-green.log | grep -E "ThreadSanitizer|Test Case.*(passed|failed)|TEST" | head -10
+```
+Expected:
+- `Test Case '-[FronteggSwiftTests.FronteggAuthFeatureFlagsRaceTests test_featureFlags_concurrentReassignmentAndRead_doesNotRace]' passed`
+- NO `WARNING: ThreadSanitizer` lines in `/tmp/race-green.log`
+- `** TEST SUCCEEDED **`
+
+If TSan still reports a race, the lock is being applied somewhere it shouldn't be. Re-read your edits — particularly that `_featureFlags` is `private` and not accessed anywhere outside the accessor + init.
+
+- [ ] **Step 5: Run the FULL unit-test suite under TSan to confirm no other races surface**
+
+```bash
+xcodebuild test \
+  -scheme FronteggSwift \
+  -destination "platform=iOS Simulator,name=iPhone 16" \
+  -only-testing:FronteggSwiftTests \
+  -enableThreadSanitizer YES \
+  -enableCodeCoverage NO \
+  -parallel-testing-enabled NO 2>&1 | tee /tmp/full-suite-tsan.log | tail -20
+```
+Expected:
+- `** TEST SUCCEEDED **`
+- Total time well under 15 min (more like 5–8 min)
+- `grep -c "WARNING: ThreadSanitizer" /tmp/full-suite-tsan.log` returns `0`
+
+If a different race surfaces here that's not on `featureFlags`, STOP and report. Don't try to fix it in this PR — that's separate scope per the spec's non-goals.
+
+- [ ] **Step 6: Commit the fix**
+
+```bash
+git add Sources/FronteggSwift/FronteggAuth.swift
+git commit -m "$(cat <<'EOF'
+fix(FronteggAuth): serialize featureFlags reads/writes via NSLock
+
+The previous `public var featureFlags: FeatureFlags` stored property
+allowed concurrent main-thread reassignment (from manualInit and the
+4 region-switch entry points in FronteggAuth+RegionManagement.swift)
+to race with background-thread reads in startPostConnectivityServices()
+and SocialLoginUrlGenerator. TSan reported this race in CI; the resulting
+abort wedged xcodebuild for 25+ minutes on every PR.
+
+Convert featureFlags to a computed property backed by a private
+_featureFlags storage var guarded by an NSLock. Every existing call
+site reads/writes through the public property unchanged — locking is
+transparent.
+
+Init writes _featureFlags directly because the property must be
+initialized before the setter (which reads _featureFlags) is safe.
+This is the only place that touches _featureFlags directly.
+
+The new FronteggAuthFeatureFlagsRaceTests regression test goes from
+RED to GREEN with this commit.
+
+The `api` and `entitlements` properties share the same reassignment
+pattern in FronteggAuth+RegionManagement.swift — they are flagged for
+a follow-up PR in CONTRIBUTING.md but not addressed here.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Promote TSan to a required check
+
+Now that the race is fixed, drop the workarounds that made the TSan job advisory.
+
+**Files:**
+- Modify: `.github/workflows/demo-e2e.yml` (the `unit-tests-tsan:` job block, currently around lines 55–95)
+
+- [ ] **Step 1: Drop `continue-on-error`, tighten timeout, drop TSAN_OPTIONS, drop tolerance line**
+
+In [`.github/workflows/demo-e2e.yml`](../../../.github/workflows/demo-e2e.yml), find the `unit-tests-tsan:` job. Replace the entire job block with:
+
+```yaml
+  unit-tests-tsan:
+    name: "Unit Tests (Thread Sanitizer)"
+    runs-on: "macos-15-xlarge"
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Reset SwiftPM artifact cache
+        run: bash .github/scripts/reset_swiftpm_artifact_cache.sh
+
+      - name: Run Unit Tests with Thread Sanitizer
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme FronteggSwift \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -only-testing:FronteggSwiftTests \
+            -resultBundlePath "$RUNNER_TEMP/unit-tests-tsan.xcresult" \
+            -enableThreadSanitizer YES \
+            -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            2>&1 | tee "$RUNNER_TEMP/unit-tests-tsan.log"
+
+      - name: Upload TSan artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: unit-tests-tsan-results
+          path: |
+            ${{ runner.temp }}/unit-tests-tsan.log
+            ${{ runner.temp }}/unit-tests-tsan.xcresult
+          retention-days: 7
+```
+
+Compared to the previous version, this removes:
+- `continue-on-error: true` — TSan findings now fail the PR
+- The `env: TSAN_OPTIONS: ...` block — abort-on-error is irrelevant when no race fires
+- The `|| echo "xcodebuild exited non-zero ..."` tolerance line — non-zero exit is now a real failure
+- The multi-line "Advisory:" comment above `timeout-minutes` — no longer advisory
+
+The job stays at `timeout-minutes: 15` (a comfortable safety net — the suite should complete in well under 10 minutes).
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/demo-e2e.yml')); print('YAML OK')"
+```
+Expected: `YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/demo-e2e.yml
+git commit -m "$(cat <<'EOF'
+ci(tsan): promote Thread Sanitizer to a required check
+
+The FronteggAuth.featureFlags race that caused the 25-min hang is
+fixed in the previous commit. With no race left to detect, the workarounds
+that made this job advisory are no longer needed:
+
+- Drop `continue-on-error: true` — TSan findings now fail the PR.
+- Drop `TSAN_OPTIONS=halt_on_error=1:abort_on_error=1` — abort behavior
+  is irrelevant when no race fires.
+- Drop the `|| echo "..."` tolerance after xcodebuild — a non-zero exit
+  is now a genuine signal.
+
+Job timeout stays at 15 minutes as a safety net; the suite is expected
+to complete in well under 10 minutes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update CONTRIBUTING.md
+
+Move the now-fixed race from "Known TSan findings" to a "Past findings" entry, and flag the related-but-still-open `api`/`entitlements` reassignment pattern.
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (the "Thread Sanitizer — currently advisory" section)
+
+- [ ] **Step 1: Replace the "Thread Sanitizer — currently advisory" section**
+
+Find the section that starts with `### Thread Sanitizer — currently advisory` in [`CONTRIBUTING.md`](../../../CONTRIBUTING.md). Replace it (from that heading down through the entire fenced code block plus the paragraphs describing the race and the fix instructions, up to but not including the next `## ` heading — which should be `## Regression-test convention`) with:
+
+```markdown
+### Thread Sanitizer
+
+The `Unit Tests (Thread Sanitizer)` job is a required check on every PR. It runs `FronteggSwiftTests` with `-enableThreadSanitizer YES`; any TSan finding fails the PR.
+
+Job timeout: 15 minutes (typical run is under 10).
+
+#### Past findings (resolved)
+
+- **`FronteggAuth.featureFlags` data race** — concurrent main-thread reassignment (from `manualInit` and region-switch entry points) racing with background-thread reads in `startPostConnectivityServices()` and `SocialLoginUrlGenerator`. Fixed in PR [#264](https://github.com/frontegg/frontegg-ios-swift/pull/264) by serializing reads/writes through an `NSLock`. The regression is pinned by `FronteggAuthFeatureFlagsRaceTests`.
+
+#### Known follow-up
+
+`FronteggAuth.api` and `FronteggAuth.entitlements` share the exact reassignment pattern as `featureFlags` did — they are reassigned in the same four sites in [`FronteggAuth+RegionManagement.swift`](Sources/FronteggSwift/auth/FronteggAuth+RegionManagement.swift) and read across multiple threads. TSan did not surface those races on the test ordering we ran, but the same fix pattern (lock-backed computed property) should be applied to both as a follow-up PR before they bite in production region-switch flows.
+```
+
+- [ ] **Step 2: Verify markdown structure**
+
+```bash
+test -f CONTRIBUTING.md && \
+  grep -c "### Thread Sanitizer" CONTRIBUTING.md && \
+  grep -c "currently advisory" CONTRIBUTING.md
+```
+Expected:
+- First `grep -c` returns `1` (one section header now)
+- Second `grep -c` returns `0` (no more "currently advisory" wording)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "$(cat <<'EOF'
+docs: move FronteggAuth.featureFlags race to "Past findings"
+
+The race is fixed in this PR; documentation now reflects that the TSan
+job is required (not advisory) and the FeatureFlags race is resolved.
+
+Adds a "Known follow-up" pointer for the same reassignment pattern on
+FronteggAuth.api and FronteggAuth.entitlements, which will need the
+same lock-backed treatment in a subsequent PR.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Push and verify CI
+
+- [ ] **Step 1: Verify commit ordering**
+
+```bash
+git log --oneline origin/master..HEAD
+```
+Expected (newest first):
+
+1. `docs: move FronteggAuth.featureFlags race to "Past findings"`
+2. `ci(tsan): promote Thread Sanitizer to a required check`
+3. `fix(FronteggAuth): serialize featureFlags reads/writes via NSLock`
+4. `test: add red regression test for FronteggAuth.featureFlags race`
+5. `docs: add spec for FronteggAuth.featureFlags race fix` (from earlier in the brainstorm)
+6. (prior commits from PR #264)
+
+If the order is different, rebase interactively to match. The test→fix split must be preserved so the RED commit is bisectable.
+
+- [ ] **Step 2: Push to PR #264**
+
+```bash
+git push origin remove-tsan-ci-job 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Watch the TSan job**
+
+```bash
+gh pr checks 264 --required=false 2>&1 | grep -E "Thread Sanitizer|Combine"
+```
+
+Expected after ~5–10 minutes:
+- `Unit Tests (Thread Sanitizer)  pass  X m Y s` (well under 15 min, no `continue-on-error` because it's a required check now)
+- `Combine Results & Summary  pass  17s`
+
+If `Unit Tests (Thread Sanitizer)` fails:
+- `gh api repos/frontegg/frontegg-ios-swift/actions/jobs/<JOB_ID>/logs | grep -E "ThreadSanitizer|Test Case.*failed"` to see which test or race failed
+- If a different race surfaces (e.g. on `api` or `entitlements`): roll the CI promotion back (revert Task 3's commit) so the PR can ship the FeatureFlags fix without being blocked by an unrelated finding, and open a follow-up issue.
+
+- [ ] **Step 4: Confirm Combine Summary passes downstream**
+
+```bash
+gh pr checks 264 2>&1 | grep -E "fail" | head -5
+```
+Expected: no `fail` rows (or only pre-existing flakes unrelated to the TSan path).
+
+---
+
+## Self-review checklist (already run by author)
+
+- ✅ **Spec coverage:**
+  - "Lock-backed computed property" → Task 2 Step 1
+  - "Init point" (`_featureFlags` direct init) → Task 2 Step 2
+  - "Reassignment sites" (RegionManagement extensions unchanged) → no task needed; they go through the public setter
+  - "Read sites" (no changes) → no task needed
+  - "Testing — new regression test" → Task 1
+  - "Local TSan verification" → Task 1 Step 3 (RED) + Task 2 Step 4 (GREEN)
+  - "Full-suite TSan verification on CI" → Task 5 Step 3
+  - PR commit structure (4 commits) → Tasks 1, 2, 3, 4 each end in a commit
+- ✅ **Placeholder scan:** no TBD / TODO / "handle appropriately". Every code step includes the full code. Every command has the expected output.
+- ✅ **Type consistency:** `_featureFlags` (private storage), `featureFlagsLock` (lock), `featureFlags` (public computed) — consistent across all tasks. `FronteggAuthFeatureFlagsRaceTests` class name + test method name match across Task 1 (creation) and Task 5 (CI lookup).
+- ✅ **Bisectability:** the test commit (Task 1) lands BEFORE the fix commit (Task 2), so `git checkout <test-commit-SHA>` reproduces the bug for any future engineer who needs to verify.

--- a/docs/superpowers/specs/2026-05-18-featureflags-race-fix-design.md
+++ b/docs/superpowers/specs/2026-05-18-featureflags-race-fix-design.md
@@ -1,0 +1,156 @@
+# Fix `FronteggAuth.featureFlags` data race
+
+Date: 2026-05-18
+Status: Approved — ready for implementation plan
+Tracking: PR [#264](https://github.com/frontegg/frontegg-ios-swift/pull/264) (TSan job currently advisory because of this race)
+
+## Background
+
+Thread Sanitizer detected a real data race on `FronteggAuth.featureFlags`:
+
+```
+Write of size 8 by main thread:
+  FronteggAuth.featureFlags.setter ← FronteggAuth.manualInit ← FronteggApp.manualInit
+  ← <NewTest>.setUp()
+
+Previous read of size 8 by thread T19 (GCD worker):
+  FronteggAuth.featureFlags.getter ← FronteggAuth.startPostConnectivityServices() async
+  ← scheduled by <PriorTest>.setUp() via FronteggApp.shared.init()
+```
+
+The race surfaces in two ways:
+
+| Scenario | Where | Severity |
+|---|---|---|
+| Test isolation | Prior test's `startPostConnectivityServices()` still running on a GCD worker when next test's `setUp()` calls `manualInit` and reassigns `featureFlags`. | Test-only — causes the TSan CI job to hang at 15-min timeout, preventing artifact upload, which makes Combine Summary fail at 11s on every PR. |
+| Production region switch | App reads `featureFlags` from `SocialLoginUrlGenerator` while a user-triggered `reinitWithRegion(...)` reassigns it on the main thread. | Real production race — rare (only during multi-region region switch) but real. |
+
+## Goal
+
+Serialize all reads and writes of `FronteggAuth.featureFlags` so a reader sees a consistent reference and a writer never overlaps a reader. Close both manifestations of the race in one PR.
+
+## Non-goals
+
+- Fixing the same race pattern on `api` and `entitlements` properties (they share the reassignment pattern in `FronteggAuth+RegionManagement.swift`). Pattern established here can be extended to those in a follow-up — adding them now would balloon the diff.
+- Refactoring to `@MainActor` or actor-based concurrency. Codebase uses `NSLock` (`connectivityGenerationLock`, `logoutTransitionLock`, `entitlementsLoadLock`, etc.) — staying with the established pattern.
+- Cancelling in-flight `startPostConnectivityServices` tasks on reassignment. The lock alone closes the race; cancellation is an optimisation we don't need.
+
+## Design
+
+### Lock-backed computed property
+
+In [Sources/FronteggSwift/FronteggAuth.swift](../../../Sources/FronteggSwift/FronteggAuth.swift), replace the stored property:
+
+```swift
+public var featureFlags: FeatureFlags
+```
+
+with a lock-protected accessor pair around a private storage variable:
+
+```swift
+private let featureFlagsLock = NSLock()
+private var _featureFlags: FeatureFlags
+
+public var featureFlags: FeatureFlags {
+    get { featureFlagsLock.withLock { _featureFlags } }
+    set { featureFlagsLock.withLock { _featureFlags = newValue } }
+}
+```
+
+The `NSLock.withLock` extension already exists at [Sources/FronteggSwift/utils/NetworkStatusMonitor.swift:13](../../../Sources/FronteggSwift/utils/NetworkStatusMonitor.swift:13). The public API is unchanged — every existing read and write site continues using `self.featureFlags` exactly as before, with the lock applied transparently.
+
+### Init point
+
+The single line in `FronteggAuth.init()` at line 127:
+
+```swift
+self.featureFlags = FeatureFlags(.init(clientId: self.clientId, api: self.api))
+```
+
+stays as-is. With the computed property, this routes through the setter under lock — safe even though `init` is single-threaded, and uniform with other write sites.
+
+### Reassignment sites (extensions in `FronteggAuth+RegionManagement.swift`)
+
+All four reassignment sites (lines 18, 35, 48, 62) continue using `self.featureFlags = FeatureFlags(...)`. Each write now acquires the lock; concurrent reads from `startPostConnectivityServices` wait their turn.
+
+### Read sites
+
+No changes needed. The existing read sites (`SocialLoginUrlGenerator.swift:297, 378`, `FronteggAuth+Connectivity.swift:20-21`, any others) read through the public property, which now locks.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `Sources/FronteggSwift/FronteggAuth.swift` | Add `featureFlagsLock` + `_featureFlags`; convert `public var featureFlags` to computed property with locked getter/setter. |
+| `Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift` *(new)* | Regression test that hammers concurrent read+write to `featureFlags`. RED before fix (TSan reports race), GREEN after fix (no race). |
+| `.github/workflows/demo-e2e.yml` | After local TSan run confirms clean: drop `continue-on-error: true`, drop the `\|\| echo …` tolerance line, drop the now-redundant `TSAN_OPTIONS` (race shouldn't fire so abort behavior is irrelevant). Promote TSan to required. |
+| `CONTRIBUTING.md` | Move the `FronteggAuth.featureFlags` race from "Known TSan findings (currently advisory)" to a "Past findings (resolved)" section. Note that `api` and `entitlements` share the reassignment pattern and are flagged as follow-up. |
+
+## Testing
+
+### New regression test
+
+File: `Tests/FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests.swift`
+
+Pattern:
+
+```swift
+final class FronteggAuthFeatureFlagsRaceTests: XCTestCase {
+    func test_featureFlagsConcurrentReassignmentAndRead_doesNotRace() async {
+        let auth = FronteggAuth.shared
+        let iterations = 10_000
+
+        async let writer: Void = {
+            for _ in 0..<iterations {
+                auth.featureFlags = FeatureFlags(.init(clientId: "test", api: auth.api))
+            }
+        }()
+
+        async let reader: Void = {
+            for _ in 0..<iterations {
+                _ = auth.featureFlags
+            }
+        }()
+
+        _ = await (writer, reader)
+    }
+}
+```
+
+### Local TSan verification (red-then-green)
+
+1. Run on master (race present): `xcodebuild test -scheme FronteggSwift -enableThreadSanitizer YES -only-testing:FronteggSwiftTests/FronteggAuthFeatureFlagsRaceTests` → expect `WARNING: ThreadSanitizer: data race`.
+2. Apply the lock fix.
+3. Re-run same command → expect no TSan warnings, test passes.
+
+### Full-suite TSan verification on CI
+
+After pushing, the `Unit Tests (Thread Sanitizer)` job should:
+- Complete in ~5–10 min (not hit the 15-min timeout)
+- Report zero `WARNING: ThreadSanitizer` lines
+- Upload its artifact
+- Combine Results & Summary succeeds
+
+## Risk
+
+- **Performance:** `NSLock` acquire/release per `featureFlags` read. Hot paths read it occasionally (twice in `SocialLoginUrlGenerator`, once per `startPostConnectivityServices` call). Microsecond-level overhead — negligible.
+- **API surface:** zero public API change. Callers continue using `self.featureFlags = …` and `let x = self.featureFlags` unchanged.
+- **Deadlock potential:** the lock guards only property storage. No nested locks, no callbacks under the lock, no async work inside `withLock`. Cannot deadlock.
+- **Test flakiness:** the new race test relies on TSan to detect the absence of races. Without TSan it just exercises the property concurrently and must not crash. Deterministic.
+
+## Out-of-scope follow-ups (separate PRs)
+
+1. Apply the same lock-backed pattern to `api` and `entitlements` on `FronteggAuth`. Same reassignment pattern, same race risk during region switches.
+2. Cancel in-flight `startPostConnectivityServices` tasks when `featureFlags` (or `api`/`entitlements`) is reassigned, so they don't continue against stale state. Optimisation, not correctness.
+3. Once all three properties are protected, drop `continue-on-error: true` from the TSan job in CI (already done by this PR for `featureFlags` alone — but the others may surface new findings).
+
+## PR structure
+
+Single PR. Commit order:
+
+1. `test: add red regression test for FronteggAuth.featureFlags race` (test alone, RED on master)
+2. `fix(FronteggAuth): serialize featureFlags reads/writes via NSLock` (the fix, turns RED → GREEN)
+3. `ci(tsan): drop continue-on-error now that featureFlags race is fixed` (promote TSan to required)
+4. `docs: move featureFlags race to "Past findings" in CONTRIBUTING.md`
+
+Each commit independently revertable. The test+fix split makes red-then-green provable from `git log` alone.


### PR DESCRIPTION
## Summary

Follow-up to [#261](https://github.com/frontegg/frontegg-ios-swift/pull/261). Removes the `Unit Tests (Thread Sanitizer)` job from [.github/workflows/demo-e2e.yml](.github/workflows/demo-e2e.yml).

## Why

The TSan job that landed in #261 has two known issues:

1. **Real race in `FronteggSwift.FeLogger.dispatchToDelegate`** — reproduces locally during `LoggerDelegateTests` when run as part of the full suite. Delegate-registration writes from one test race dispatch-queue reads from another.
2. **Test-runner hang under TSan instrumentation** — even with `timeout-minutes: 25`, the job sits at ~25m26s before timing out on every PR.

Pulling the job is cleaner than leaving it as a 25-min advisory failure on every PR. Both findings are captured in `CONTRIBUTING.md` → "Known TSan findings (CI integration deferred)" for the follow-up that fixes the race and re-adds the job.

## Changes

- `.github/workflows/demo-e2e.yml` — remove the `unit-tests-tsan` job, its entry from the `summary` job's `needs:`, the artifact-download step, and the `Append Thread Sanitizer summary` step.
- `CONTRIBUTING.md` — update the "Unit tests with Thread Sanitizer" section to say it's local-only; replace the old "Thread Sanitizer — currently advisory" subsection with "Known TSan findings (CI integration deferred)" that documents both blockers for the re-add.

## Test plan

- [ ] CI: all checks pass without TSan job
- [ ] No red \`Unit Tests (Thread Sanitizer)\` mark on this PR
- [ ] After merge, future PRs no longer run TSan

🤖 Generated with [Claude Code](https://claude.com/claude-code)