### PR TITLE
fix(sdk): clear entitlements cache before reloading after tenant switch

### DIFF
--- a/Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift
@@ -252,6 +252,19 @@ extension FronteggAuth {
                 } else {
                     cancelScheduledTokenRefresh()
                 }
+                // Drop any cached entitlements before kicking off the new load. Without
+                // this:
+                //   * during the in-flight reload, getFeatureEntitlements() keeps
+                //     returning the PREVIOUS tenant's verdict (state and hasLoaded are
+                //     unchanged until performEntitlementsLoad's Task finishes);
+                //   * if the reload fails (Entitlements.load returns false on HTTP
+                //     error or decode failure without touching _state), the cache stays
+                //     pinned to the previous tenant forever.
+                // For login/init paths the cache is already empty (in-memory, no
+                // persistence), so clear() is a no-op. The behavior change is scoped to
+                // tenant switching, where setCredentialsInternal runs with a populated
+                // cache from the prior tenant.
+                entitlements.clear()
                 loadEntitlements(forceRefresh: true)
             }
 

--- a/Tests/FronteggSwiftTests/FronteggAuthEntitlementsTests.swift
+++ b/Tests/FronteggSwiftTests/FronteggAuthEntitlementsTests.swift
@@ -221,6 +221,233 @@ final class FronteggAuthEntitlementsTests: XCTestCase {
         XCTAssertEqual(auth.entitlements.state.featureKeys, Set(["beta"]))
     }
 
+    // MARK: - setCredentials entitlements cache invalidation (FR-24821)
+
+    // The customer-reported bug (FR-24821): after switching tenants on Android, the
+    // entitlements cache kept reporting the PREVIOUS tenant's verdict because
+    // setCredentialsInternal (which switchTenant routes through) called
+    // loadEntitlements(forceRefresh: true) but never invalidated the cache first. The
+    // same bug exists on the Swift SDK — see
+    // Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift around line
+    // 255. The fix adds entitlements.clear() immediately before loadEntitlements.
+    //
+    // The three tests below mirror the Android coverage in
+    // android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt:
+    //   1. Happy path — pre-load tenant A's cache, setCredentials with tenant B,
+    //      assert getFeatureEntitlements reflects tenant B. Passes on master too —
+    //      loadEntitlements was already wired — kept as a top-level FR-24821 guard.
+    //   2. In-flight window (differential) — blocks the reload response so the load
+    //      Task stays suspended; asserts hasLoaded == false WHILE the reload is in
+    //      flight. Pre-fix: hasLoaded stays true (no clear) until load completes.
+    //   3. Failed reload (differential) — reload responds 500. Entitlements.load
+    //      returns false on HTTP error without touching _state. Pre-fix: cache keeps
+    //      tenant A's {sso} forever. Post-fix: clear() ran first, cache is empty.
+
+    func test_setCredentials_reloadsEntitlementsWithNewTenantView_FR_24821_happyPath() async throws {
+        try await seedTenantAEntitlementsCacheWithSSO()
+
+        // Tenant B has no entitlements — the customer's reproduction scenario.
+        api.enqueueResponse(makeEntitlementsResponse(featureKeys: []))
+
+        let reloadStarted = expectation(description: "tenant-B entitlements reload started")
+        api.onRequestStarted = { index in
+            if index == 2 { reloadStarted.fulfill() }
+        }
+
+        await auth.setCredentials(
+            accessToken: try makeTenantBJWT(),
+            refreshToken: "tenant-B-refresh-token",
+            user: try makeTenantBUser()
+        )
+
+        await fulfillment(of: [reloadStarted], timeout: 2.0)
+
+        // The reload Task is firing; wait for it to settle (the test API responds
+        // immediately, so a brief yield is enough — no blocking involved).
+        try await waitUntilEntitlementsSettleAfterReload(
+            expectingHasLoaded: true,
+            expectedFeatureKeys: []
+        )
+
+        XCTAssertTrue(auth.entitlements.hasLoaded)
+        XCTAssertEqual(auth.entitlements.state.featureKeys, Set<String>())
+
+        // FR-24821 customer assertion: getFeatureEntitlements("sso") must reflect
+        // tenant B's reality, not tenant A's pre-switch view.
+        let entitlement = auth.getFeatureEntitlements(featureKey: "sso")
+        XCTAssertFalse(entitlement.isEntitled, "must not leak tenant A's sso verdict after switching to tenant B")
+        XCTAssertEqual(entitlement.justification, "MISSING_FEATURE", "expected MISSING_FEATURE after a successful reload on tenant B (which lacks sso)")
+    }
+
+    func test_setCredentials_clearsEntitlementsCacheBeforeReloadStarts_inFlightWindow() async throws {
+        // Differential test for the specific behavior this PR adds: entitlements.clear()
+        // runs synchronously inside MainActor.run BEFORE loadEntitlements is called.
+        // Without that ordering, getFeatureEntitlements() called during the in-flight
+        // load window would return the PREVIOUS tenant's verdict — state and hasLoaded
+        // are unchanged until performEntitlementsLoad's Task assigns _state.
+        try await seedTenantAEntitlementsCacheWithSSO()
+
+        // Block the tenant-B reload so the load Task stays suspended in
+        // api.getRequest — this lets us observe the in-flight window directly.
+        api.enqueueResponse(makeEntitlementsResponse(featureKeys: []))
+        api.blockRequest(2)
+
+        let reloadStarted = expectation(description: "tenant-B reload request started")
+        api.onRequestStarted = { index in
+            if index == 2 { reloadStarted.fulfill() }
+        }
+
+        await auth.setCredentials(
+            accessToken: try makeTenantBJWT(),
+            refreshToken: "tenant-B-refresh-token",
+            user: try makeTenantBUser()
+        )
+
+        // Wait for the HTTP request to actually fire — proves loadEntitlements was
+        // called by setCredentialsInternal.
+        await fulfillment(of: [reloadStarted], timeout: 2.0)
+
+        // CRITICAL: the reload is now in flight (blocked). With the fix, clear() ran
+        // synchronously inside MainActor.run before loadEntitlements, so the cache is
+        // already empty. Pre-fix: hasLoaded stays true (tenant A's {sso}) until the
+        // load completes — a window during which getFeatureEntitlements() leaks the
+        // previous tenant's verdict.
+        XCTAssertFalse(auth.entitlements.hasLoaded, "cache must be cleared before the reload is triggered (in-flight window)")
+        XCTAssertEqual(auth.entitlements.state.featureKeys, Set<String>(), "state must be empty before the reload completes; was \(auth.entitlements.state.featureKeys)")
+
+        // The user-facing surface: getFeatureEntitlements must not leak tenant A's
+        // verdict during the in-flight window.
+        let entitlement = auth.getFeatureEntitlements(featureKey: "sso")
+        XCTAssertFalse(entitlement.isEntitled, "getFeatureEntitlements must not return tenant A's sso verdict while tenant B's reload is in flight")
+
+        // Unblock the request so the background Task can finish and the test tears
+        // down cleanly.
+        api.resumeRequest(2)
+    }
+
+    func test_setCredentials_failedReloadDoesNotLeakPreviousTenantView() async throws {
+        try await seedTenantAEntitlementsCacheWithSSO()
+
+        // Tenant B's reload fails — 5xx, network flake, whatever. Entitlements.load
+        // returns false on HTTP error WITHOUT touching _state, so any pre-existing
+        // cache would survive. Differential check: with the fix, clear() ran first.
+        api.enqueueResponse(makeFailedEntitlementsResponse(statusCode: 500))
+
+        let reloadStarted = expectation(description: "tenant-B reload request started")
+        api.onRequestStarted = { index in
+            if index == 2 { reloadStarted.fulfill() }
+        }
+
+        await auth.setCredentials(
+            accessToken: try makeTenantBJWT(),
+            refreshToken: "tenant-B-refresh-token",
+            user: try makeTenantBUser()
+        )
+
+        await fulfillment(of: [reloadStarted], timeout: 2.0)
+
+        // Wait for the failed reload to finish so the load Task has fully cycled.
+        try await waitUntilEntitlementsSettleAfterReload(
+            expectingHasLoaded: false,
+            expectedFeatureKeys: []
+        )
+
+        // Pre-fix: the cache still holds tenant A's {sso} forever (load failed without
+        // touching _state). Post-fix: clear() ran before loadEntitlements.
+        XCTAssertFalse(auth.entitlements.hasLoaded, "cache must be cleared on tenant switch even when the reload fails")
+        XCTAssertEqual(auth.entitlements.state.featureKeys, Set<String>(), "state must be empty after a failed reload; was \(auth.entitlements.state.featureKeys)")
+
+        // getFeatureEntitlements must not leak tenant A's verdict. Note that the Swift
+        // SDK's Entitlements.checkFeature does NOT gate on hasLoaded (unlike Android,
+        // which returns ENTITLEMENTS_NOT_LOADED when the cache hasn't been populated).
+        // The Swift surface returns MISSING_FEATURE based on the empty state — still a
+        // correct, non-leaking verdict for the customer-visible boolean, but the
+        // justification is platform-specific. The isEntitled assertion below is the
+        // load-bearing differential; the justification assertion documents Swift's
+        // actual contract (and would be the place to update if checkFeature is ever
+        // changed to mirror Android's "not loaded" reporting).
+        let entitlement = auth.getFeatureEntitlements(featureKey: "sso")
+        XCTAssertFalse(entitlement.isEntitled, "getFeatureEntitlements must not leak tenant A's sso verdict after a failed reload")
+        XCTAssertEqual(entitlement.justification, "MISSING_FEATURE", "Swift's checkFeature returns MISSING_FEATURE on empty state; was \(entitlement.justification ?? "<nil>")")
+    }
+
+    // MARK: - Helpers for the FR-24821 tests
+
+    /// Pre-populates the entitlements cache with tenant A's `{sso}` set by enqueuing a
+    /// success response and calling `entitlements.load` directly. Asserts the cache
+    /// is populated as expected before the test proceeds.
+    private func seedTenantAEntitlementsCacheWithSSO() async throws {
+        api.enqueueResponse(makeEntitlementsResponse(featureKeys: ["sso"]))
+        let loaded = await auth.entitlements.load(accessToken: "tenant-A-access-token")
+        XCTAssertTrue(loaded, "Sanity check: tenant A's entitlements must pre-load successfully")
+        XCTAssertTrue(auth.entitlements.hasLoaded, "Sanity check: hasLoaded must be true after pre-load")
+        XCTAssertTrue(auth.entitlements.state.featureKeys.contains("sso"), "Sanity check: tenant A's cache must hold sso before setCredentials runs")
+    }
+
+    /// Builds a syntactically-valid JWT for tenant B with an `exp` claim 1 hour in the
+    /// future. setCredentialsInternal decodes the JWT for the refresh-timer offset, so
+    /// the token format has to be parseable — see `TestDataFactory.makeJWT`.
+    private func makeTenantBJWT() throws -> String {
+        let payload: [String: Any] = [
+            "sub": "user-1",
+            "tenantId": "tenant-B",
+            "tenantIds": ["tenant-A", "tenant-B"],
+            "email": "test@example.com",
+            "exp": Int(Date().timeIntervalSince1970 + 3600)
+        ]
+        return try TestDataFactory.makeJWT(payloadDict: payload)
+    }
+
+    /// Builds a `User` for tenant B via `User.fromJWT` so setCredentialsInternal skips
+    /// the `api.me()` path entirely (the `BlockingAuthEntitlementsApi` doesn't
+    /// implement `me`, so going through it would explode).
+    private func makeTenantBUser() throws -> User {
+        let claims: [String: Any] = [
+            "sub": "user-1",
+            "name": "Test User",
+            "email": "test@example.com",
+            "tenantId": "tenant-B",
+            "tenantIds": ["tenant-A", "tenant-B"]
+        ]
+        guard let user = User.fromJWT(claims) else {
+            throw NSError(domain: "FronteggAuthEntitlementsTests", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to build tenant-B user via User.fromJWT"])
+        }
+        return user
+    }
+
+    /// 500 response — exercises the path where `api.getRequest` returns an unsuccessful
+    /// HTTP response, causing `Entitlements.load` to return `false` without touching
+    /// `_state`. This is the exact gap that pinned the cache to the previous tenant
+    /// pre-fix.
+    private func makeFailedEntitlementsResponse(statusCode: Int) -> (Data, HTTPURLResponse) {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.example.com/frontegg/entitlements/api/v2/user-entitlements")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (Data(), response)
+    }
+
+    /// Polls until the entitlements cache reaches the expected state, with a 2-second
+    /// safety timeout. The actual settle time is bounded by the test API's
+    /// synchronous response, so this typically loops once or twice.
+    private func waitUntilEntitlementsSettleAfterReload(
+        expectingHasLoaded expectedHasLoaded: Bool,
+        expectedFeatureKeys: Set<String>,
+        timeout: TimeInterval = 2.0,
+        pollInterval: TimeInterval = 0.01
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if auth.entitlements.hasLoaded == expectedHasLoaded
+                && auth.entitlements.state.featureKeys == expectedFeatureKeys {
+                return
+            }
+            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+    }
+
     private func makeEntitlementsResponse(featureKeys: [String]) -> (Data, HTTPURLResponse) {
         let features = Dictionary(uniqueKeysWithValues: featureKeys.map { ($0, [String: String]()) })
         let json: [String: Any] = [


### PR DESCRIPTION
## Summary

Port of [frontegg/frontegg-android-kotlin#254](https://github.com/frontegg/frontegg-android-kotlin/pull/254) to the Swift SDK. Adds the missing cache invalidation step in `setCredentialsInternal` so `getFeatureEntitlements` cannot leak the previous tenant's verdict during the in-flight reload window or after a failed reload.

## Why

`setCredentialsInternal` — the workhorse that `switchTenant` routes through after re-minting tokens — fires `loadEntitlements(forceRefresh: true)` on the new tenant's access token but never invalidates the cache first. Two windows still leak the previous tenant's view:

1. **In-flight reload** — between `loadEntitlements` being called and `performEntitlementsLoad`'s `Task` writing the new state, `getFeatureEntitlements()` keeps returning the PREVIOUS tenant's verdict. State and `hasLoaded` are unchanged until the load completes.

2. **Failed reload** — `Entitlements.load` returns `false` on HTTP error or decode failure WITHOUT touching `_state` ([Entitlements.swift:74-78](Sources/FronteggSwift/services/Entitlements.swift#L74-L78), [:94-97](Sources/FronteggSwift/services/Entitlements.swift#L94-L97)). The cache is pinned to the previous tenant forever — until another `getUserEntitlements` call eventually succeeds, or until the SDK process restarts.

**Customer-visible symptom (FR-24821):** after switching to a tenant without the `sso` feature, `fronteggAuth.getFeatureEntitlements(featureKey: "sso")` still reports `isEntitled = true`. With this change, the verdict is one of:

- the new tenant's verdict (reload succeeded — normal case), or
- `Entitlement(isEntitled: false, justification: "MISSING_FEATURE")` on the empty cache during the in-flight window or after a failed reload.

Never the previous tenant's verdict.

> NB: Swift's `Entitlements.checkFeature` reports `MISSING_FEATURE` on an empty state, whereas the Android counterpart returns `ENTITLEMENTS_NOT_LOADED` when `hasLoaded == false`. Same defensive boolean (`isEntitled == false`), different justification string. Documented in the failed-reload test. This PR doesn't change the justification surface — that's a separate platform-parity item if we ever want to align.

## The fix

One line in `setCredentialsInternal`, immediately before `loadEntitlements(forceRefresh: true)`:

```swift
entitlements.clear()
loadEntitlements(forceRefresh: true)
```

For login / restore-from-storage paths the cache is already empty (in-memory only, no persistence), so the clear is a no-op. The behavior change is scoped to tenant switching, where `setCredentialsInternal` runs with a populated cache from the prior tenant.

## Tests

Three regression tests in [`FronteggAuthEntitlementsTests`](Tests/FronteggSwiftTests/FronteggAuthEntitlementsTests.swift), sharing a `seedTenantAEntitlementsCacheWithSSO()` helper plus tenant-B JWT / User builders plus a `BlockingAuthEntitlementsApi`-driven poll helper:

| # | Test | What it covers | FAILS without fix? |
|---|---|---|---|
| 1 | `…(FR-24821 happy path)` | Successful reload returning empty entitlements for tenant B. Asserts `hasLoaded` true, `state.featureKeys` empty, `getFeatureEntitlements("sso") → MISSING_FEATURE`. | No — `loadEntitlements` is already fired. Kept as top-level guard for the customer-reported symptom. |
| 2 | `…in-flight window` | Blocks the reload's HTTP response so the load Task stays suspended in `api.getRequest`. Asserts cache is already empty + `hasLoaded` is already false BEFORE load completes. | **Yes** — without fix, `hasLoaded` stays true (tenant A's `{sso}`) until load completes. |
| 3 | `…failed reload` | Reload responds 500. `Entitlements.load` returns false on HTTP error without touching `_state`. With fix: cache empty, `getFeatureEntitlements("sso").isEntitled == false`. | **Yes** — without fix, cache stays pinned to tenant A's `{sso}` forever. |

Differential verified by temporarily removing `entitlements.clear()` from `setCredentialsInternal` and re-running: tests 2 and 3 fail, test 1 passes.

## Test plan

- [x] All 3 new tests pass with fix
- [x] Tests 2 and 3 fail without fix (differential — temporarily reverted the production change and re-ran)
- [x] Test 1 passes on bare master (top-level FR-24821 regression guard)
- [x] `xcodebuild -scheme FronteggSwift -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' test` — full suite **683 tests / 0 failures / 18 skipped**
- [ ] Manual: in a demo app, force a tenant-B reload failure (e.g., kill network mid-switch) and confirm `getFeatureEntitlements("sso")` no longer reports the previous tenant's verdict

## Diff

- `+13 lines` in [FronteggAuth+CredentialHydration.swift](Sources/FronteggSwift/auth/FronteggAuth+CredentialHydration.swift) (1 line of code + 12-line explanatory comment).
- `+227 lines` in [FronteggAuthEntitlementsTests.swift](Tests/FronteggSwiftTests/FronteggAuthEntitlementsTests.swift) (helpers + 3 tests).

## Related

- [frontegg-android-kotlin#254](https://github.com/frontegg/frontegg-android-kotlin/pull/254) — the equivalent Android fix this is ported from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)