### PR TITLE
fix(sdk): port full entitlement decision logic from web SDK (FR-24821)

### DIFF
--- a/Sources/FronteggSwift/auth/FronteggAuth+Entitlements.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Entitlements.swift
@@ -110,26 +110,51 @@ extension FronteggAuth {
         }
     }
 
-    public func getFeatureEntitlements(featureKey: String) -> Entitlement {
+    public func getFeatureEntitlements(featureKey: String, customAttributes: [String: Any?]? = nil) -> Entitlement {
         guard self.user != nil else {
-            return Entitlement(isEntitled: false, justification: "NOT_AUTHENTICATED")
+            return Entitlement(isEntitled: false, justification: NotEntitledJustification.NOT_AUTHENTICATED)
         }
-        return entitlements.checkFeature(featureKey: featureKey)
+        return entitlements.checkFeature(
+            featureKey: featureKey,
+            attributes: attributesForEvaluation(customAttributes: customAttributes)
+        )
     }
 
-    public func getPermissionEntitlements(permissionKey: String) -> Entitlement {
+    public func getPermissionEntitlements(permissionKey: String, customAttributes: [String: Any?]? = nil) -> Entitlement {
         guard self.user != nil else {
-            return Entitlement(isEntitled: false, justification: "NOT_AUTHENTICATED")
+            return Entitlement(isEntitled: false, justification: NotEntitledJustification.NOT_AUTHENTICATED)
         }
-        return entitlements.checkPermission(permissionKey: permissionKey)
+        return entitlements.checkPermission(
+            permissionKey: permissionKey,
+            attributes: attributesForEvaluation(customAttributes: customAttributes)
+        )
     }
 
-    public func getEntitlements(options: EntitledToOptions) -> Entitlement {
+    public func getEntitlements(options: EntitledToOptions, customAttributes: [String: Any?]? = nil) -> Entitlement {
         switch options {
         case .featureKey(let key):
-            return getFeatureEntitlements(featureKey: key)
+            return getFeatureEntitlements(featureKey: key, customAttributes: customAttributes)
         case .permissionKey(let key):
-            return getPermissionEntitlements(permissionKey: key)
+            return getPermissionEntitlements(permissionKey: key, customAttributes: customAttributes)
         }
+    }
+
+    /// Builds the attribute bag rule conditions are evaluated against — JWT claims
+    /// from the current access token plus any host-app `customAttributes`. The
+    /// downstream `AttributesPreparer` adds the `frontegg.` and `jwt.` prefixes
+    /// (e.g. `frontegg.tenantId`, `jwt.email`) so a server-emitted rule like
+    /// `attribute = "frontegg.tenantId"` can look the value up directly.
+    ///
+    /// Decoding the JWT inline keeps each entitlement check honest against the
+    /// current token — if the SDK just switched tenants and the JWT now carries
+    /// `tenantId = "B"`, the check sees `B` immediately, without waiting for the
+    /// entitlements reload to settle.
+    private func attributesForEvaluation(customAttributes: [String: Any?]?) -> Attributes {
+        var jwtClaims: [String: Any?] = [:]
+        if let token = self.accessToken, !token.isEmpty,
+           let decoded = try? JWTHelper.decode(jwtToken: token) {
+            jwtClaims = decoded.mapValues { $0 as Any? }
+        }
+        return Attributes(custom: customAttributes, jwt: jwtClaims)
     }
 }

--- a/Sources/FronteggSwift/entitlements/AttributesPreparer.swift
+++ b/Sources/FronteggSwift/entitlements/AttributesPreparer.swift
@@ -1,0 +1,76 @@
+//
+//  AttributesPreparer.swift
+//  FronteggSwift
+//
+//  Port of `prepareAttributes` from @frontegg/entitlements-javascript-commons.
+//
+
+import Foundation
+
+enum AttributesPreparer {
+
+    static let fronteggPrefix = "frontegg."
+    static let jwtPrefix = "jwt."
+
+    /// Merges three sources into the rule-evaluation attribute bag:
+    ///   1. Custom attributes provided by the host app, used as-is (e.g.
+    ///      `"customAttr"`).
+    ///   2. Frontegg-derived attributes (`email`, `emailVerified`, `tenantId`,
+    ///      `userId`) pulled out of the JWT claims and prefixed `frontegg.`.
+    ///   3. The full flattened JWT claim tree, prefixed `jwt.` — so a nested
+    ///      `{"metadata": {"plan": "pro"}}` claim becomes `jwt.metadata.plan`.
+    static func prepare(_ attributes: Attributes) -> [String: Any?] {
+        var merged: [String: Any?] = [:]
+        if let custom = attributes.custom {
+            for (k, v) in custom { merged[k] = v }
+        }
+        let jwt = attributes.jwt ?? [:]
+        let flatJwt = flatten(jwt)
+        for (k, v) in defaultFronteggAttributes(jwt) {
+            merged[fronteggPrefix + k] = v
+        }
+        for (k, v) in flatJwt {
+            merged[jwtPrefix + k] = v
+        }
+        return merged
+    }
+
+    /// Frontegg-canonical fields derived from JWT claims, exactly mirroring web's
+    /// `defaultFronteggAttributesMapper`.
+    ///
+    ///   `jwt.id` (or `sub`) → `frontegg.userId`
+    ///   `jwt.email`, `jwt.email_verified`, `jwt.tenantId` → corresponding camelCase
+    private static func defaultFronteggAttributes(_ jwt: [String: Any?]) -> [String: Any?] {
+        var out: [String: Any?] = [:]
+        out["email"] = jwt["email"] ?? nil
+        out["emailVerified"] = jwt["email_verified"] ?? nil
+        out["tenantId"] = jwt["tenantId"] ?? nil
+        // Web maps from `jwt.id`; mobile typically has `sub` instead. Fall through.
+        out["userId"] = jwt["id"] ?? jwt["sub"] ?? nil
+        return out
+    }
+
+    /// Depth-first flattening with `.`-joined keys. List values are kept as-is —
+    /// they're matched element-wise by operations like `in_list`/`contains` against
+    /// the attribute payload's `list` field, not by attribute path. Matches web.
+    static func flatten(_ input: [String: Any?], prefix: String = "") -> [String: Any?] {
+        var out: [String: Any?] = [:]
+        for (k, v) in input {
+            let key = prefix.isEmpty ? k : "\(prefix).\(k)"
+            if let nested = v as? [String: Any?] {
+                for (nk, nv) in flatten(nested, prefix: key) {
+                    out[nk] = nv
+                }
+            } else if let nested = v as? [String: Any] {
+                // JSONSerialization gives us `[String: Any]`, not `[String: Any?]`.
+                let normalized = nested.mapValues { $0 as Any? }
+                for (nk, nv) in flatten(normalized, prefix: key) {
+                    out[nk] = nv
+                }
+            } else {
+                out[key] = v
+            }
+        }
+        return out
+    }
+}

--- a/Sources/FronteggSwift/entitlements/Evaluators.swift
+++ b/Sources/FronteggSwift/entitlements/Evaluators.swift
@@ -1,0 +1,209 @@
+//
+//  Evaluators.swift
+//  FronteggSwift
+//
+//  Port of the condition / rule / plan / featureFlag / feature / permission
+//  evaluator chain from @frontegg/entitlements-javascript-commons.
+//
+
+import Foundation
+
+enum ConditionEvaluator {
+    /// Mirrors `createConditionEvaluator` from web. A condition is true iff the
+    /// value sanitizes, the attribute exists in the prepared map, the operation
+    /// handler returns true. `negate` inverts the final result — but only when
+    /// sanitization/handler succeed; an absent attribute is unconditionally false
+    /// (matches web's `attributes[key] !== undefined` precheck before negate).
+    static func evaluate(_ condition: Condition, attributes: [String: Any?]) -> Bool {
+        guard let payload = SanitizerResolver.sanitize(condition.op, value: condition.rawValue()),
+              let handler = OperationResolver.resolve(condition.op, payload: payload) else {
+            return false
+        }
+        guard attributes.keys.contains(condition.attribute) else { return false }
+        let value = attributes[condition.attribute] ?? nil
+        guard value != nil else { return false }
+        let raw = handler(value)
+        return condition.negate ? !raw : raw
+    }
+}
+
+enum RuleEvaluationResult {
+    case treatable
+    case insufficient
+}
+
+enum RuleEvaluator {
+    /// A rule is `treatable` iff every condition evaluates true (web only ships
+    /// `ConditionLogicEnum.And`; if the server ever introduces other operators, the
+    /// `ConditionLogic` enum is the place to extend).
+    static func evaluate(_ rule: Rule, attributes: [String: Any?]) -> RuleEvaluationResult {
+        let all = rule.conditions.allSatisfy { ConditionEvaluator.evaluate($0, attributes: attributes) }
+        return all ? .treatable : .insufficient
+    }
+}
+
+enum PlanEvaluator {
+    /// Rules are checked in document order. The first rule whose conditions all
+    /// match produces the plan's treatment; if no rule matches, the plan falls
+    /// back to `defaultTreatment`. This is the layer that turns
+    /// `defaultTreatment: "false"` into "not entitled to SSO" on web in FR-24821.
+    static func evaluate(_ plan: Plan, attributes: [String: Any?]) -> Treatment {
+        if let matching = (plan.rules ?? []).first(where: {
+            RuleEvaluator.evaluate($0, attributes: attributes) == .treatable
+        }) {
+            return matching.treatment
+        }
+        return plan.defaultTreatment
+    }
+}
+
+enum FeatureFlagEvaluator {
+    ///   * flag off  → `offTreatment`
+    ///   * flag on   → first matching rule's treatment, else `defaultTreatment`
+    static func evaluate(_ flag: FeatureFlag, attributes: [String: Any?]) -> Treatment {
+        guard flag.on else { return flag.offTreatment }
+        if let matching = (flag.rules ?? []).first(where: {
+            RuleEvaluator.evaluate($0, attributes: attributes) == .treatable
+        }) {
+            return matching.treatment
+        }
+        return flag.defaultTreatment
+    }
+}
+
+enum IsEntitledToFeature {
+    /// Port of `evaluateIsEntitledToFeature`. Three-evaluator chain with the same
+    /// priorities as web:
+    ///   1. `directEntitlementEvaluator` — `expireTime != nil`, not expired
+    ///   2. `featureFlagEvaluator`        — feature-flag on/off + rules
+    ///   3. `planTargetingRulesEvaluator` — for each linked plan, rules then default
+    ///
+    /// First evaluator returning `isEntitled = true` wins. Otherwise
+    /// `BUNDLE_EXPIRED` if any evaluator reported it, else `MISSING_FEATURE`.
+    static func evaluate(
+        _ featureKey: String,
+        context: UserEntitlementsContext?,
+        attributes: Attributes = Attributes()
+    ) -> EntitlementResult {
+        guard let context = context else {
+            return EntitlementResult(isEntitled: false, justification: NotEntitledJustification.MISSING_FEATURE)
+        }
+        let prepared = AttributesPreparer.prepare(attributes)
+        var results: [EntitlementResult] = []
+        for evaluator in featureEvaluators {
+            results.append(evaluator(featureKey, context, prepared))
+            if !shouldContinue(results) { break }
+        }
+        return aggregate(results)
+    }
+
+    private static let featureEvaluators: [(String, UserEntitlementsContext, [String: Any?]) -> EntitlementResult] = [
+        directEntitlementEvaluator,
+        featureFlagEvaluator,
+        planTargetingRulesEvaluator
+    ]
+
+    /// Mirrors `direct-entitlement.evaluator.ts`.
+    ///   * `expireTime` nil  → feature is not directly assigned → `MISSING_FEATURE`
+    ///   * `expireTime` = -1 → permanently assigned → entitled
+    ///   * `expireTime` > now → assigned, not yet expired → entitled
+    ///   * `expireTime` < now → bundle expired → `BUNDLE_EXPIRED`
+    static func directEntitlementEvaluator(
+        _ featureKey: String,
+        _ context: UserEntitlementsContext,
+        _ attributes: [String: Any?]
+    ) -> EntitlementResult {
+        if let feature = context.features[featureKey], let expireTime = feature.expireTime {
+            let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let expired = expireTime != FeatureDetail.NO_EXPIRATION_TIME && expireTime < nowMs
+            if !expired { return EntitlementResult(isEntitled: true) }
+            return EntitlementResult(isEntitled: false, justification: NotEntitledJustification.BUNDLE_EXPIRED)
+        }
+        return EntitlementResult(isEntitled: false, justification: NotEntitledJustification.MISSING_FEATURE)
+    }
+
+    static func featureFlagEvaluator(
+        _ featureKey: String,
+        _ context: UserEntitlementsContext,
+        _ attributes: [String: Any?]
+    ) -> EntitlementResult {
+        guard let feature = context.features[featureKey], let flag = feature.featureFlag else {
+            return missingFeature()
+        }
+        let treatment = FeatureFlagEvaluator.evaluate(flag, attributes: attributes)
+        return treatment == .true ? EntitlementResult(isEntitled: true) : missingFeature()
+    }
+
+    static func planTargetingRulesEvaluator(
+        _ featureKey: String,
+        _ context: UserEntitlementsContext,
+        _ attributes: [String: Any?]
+    ) -> EntitlementResult {
+        guard let feature = context.features[featureKey], !feature.planIds.isEmpty else {
+            return missingFeature()
+        }
+        for planId in feature.planIds {
+            guard let plan = context.plans[planId] else { continue }
+            let treatment = PlanEvaluator.evaluate(plan, attributes: attributes)
+            if treatment == .true { return EntitlementResult(isEntitled: true) }
+        }
+        return missingFeature()
+    }
+
+    private static func missingFeature() -> EntitlementResult {
+        EntitlementResult(isEntitled: false, justification: NotEntitledJustification.MISSING_FEATURE)
+    }
+
+    /// Mirrors `getResult` from `entitlement-results.utils.ts`. First
+    /// `isEntitled=true` wins; otherwise `BUNDLE_EXPIRED` outranks
+    /// `MISSING_FEATURE` so the host app sees a more actionable justification.
+    static func aggregate(_ results: [EntitlementResult]) -> EntitlementResult {
+        var anyExpired = false
+        for r in results {
+            if r.isEntitled { return r }
+            if r.justification == NotEntitledJustification.BUNDLE_EXPIRED { anyExpired = true }
+        }
+        return EntitlementResult(
+            isEntitled: false,
+            justification: anyExpired ? NotEntitledJustification.BUNDLE_EXPIRED : NotEntitledJustification.MISSING_FEATURE
+        )
+    }
+
+    /// Mirrors `shouldContinue` — stop the chain as soon as any evaluator says yes.
+    static func shouldContinue(_ results: [EntitlementResult]) -> Bool {
+        results.allSatisfy { !$0.isEntitled }
+    }
+}
+
+enum IsEntitledToPermission {
+    /// Port of `evaluateIsEntitledToPermissions`. Two-step check:
+    ///   1. Wildcard-match the permission key against the granted permissions.
+    ///   2. If the permission isn't linked to any feature, the wildcard match is
+    ///      the whole answer. Otherwise re-run the feature evaluator chain for
+    ///      every linked feature; if any feature is entitled, the permission is
+    ///      entitled too.
+    static func evaluate(
+        _ permissionKey: String,
+        context: UserEntitlementsContext?,
+        attributes: Attributes = Attributes()
+    ) -> EntitlementResult {
+        guard let context = context else {
+            return EntitlementResult(isEntitled: false, justification: NotEntitledJustification.MISSING_PERMISSION)
+        }
+        guard PermissionMatcher.hasPermission(context.permissions, required: permissionKey) else {
+            return EntitlementResult(isEntitled: false, justification: NotEntitledJustification.MISSING_PERMISSION)
+        }
+        let linkedFeatures = context.features.filter { _, detail in
+            detail.linkedPermissions.contains(permissionKey)
+        }.map { $0.key }
+
+        if linkedFeatures.isEmpty { return EntitlementResult(isEntitled: true) }
+
+        var results: [EntitlementResult] = []
+        for featureKey in linkedFeatures {
+            results.append(IsEntitledToFeature.evaluate(featureKey, context: context, attributes: attributes))
+            if !IsEntitledToFeature.shouldContinue(results) { break }
+        }
+        return IsEntitledToFeature.aggregate(results)
+    }
+}

--- a/Sources/FronteggSwift/entitlements/Operations.swift
+++ b/Sources/FronteggSwift/entitlements/Operations.swift
@@ -1,0 +1,199 @@
+//
+//  Operations.swift
+//  FronteggSwift
+//
+//  Port of the operations + sanitizers matrix from
+//  @frontegg/entitlements-javascript-commons. Two-step protocol:
+//
+//    1. `SanitizerResolver.sanitize` narrows the raw `condition.value` payload to
+//       a strongly-typed payload. If the payload doesn't match the operation,
+//       sanitization fails and the condition is treated as `false`.
+//    2. `OperationResolver.resolve` returns a handler `(Any?) -> Bool` that runs
+//       the operation against an attribute pulled out of the prepared map. Type
+//       mismatches (e.g. operation expects String, attribute is Bool) return false.
+//
+
+import Foundation
+
+enum SanitizedPayload {
+    case singleString(String)
+    case listString([String])
+    case singleNumber(Double)
+    case numericRange(start: Double, end: Double)
+    case singleBoolean(Bool)
+    case singleDate(Date)
+    case dateRange(start: Date, end: Date)
+}
+
+enum SanitizerResolver {
+    static func sanitize(_ operation: FronteggOperation, value: [String: Any?]) -> SanitizedPayload? {
+        switch operation {
+        case .matches: return sanitizeSingleString(value)
+        case .contains, .startsWith, .endsWith, .inList: return sanitizeListString(value)
+        case .equal, .greaterThan, .greaterThanEqual, .lesserThan, .lesserThanEqual:
+            return sanitizeSingleNumber(value)
+        case .betweenNumeric: return sanitizeNumericRange(value)
+        case .is: return sanitizeSingleBoolean(value)
+        case .on, .onOrAfter, .onOrBefore: return sanitizeSingleDate(value)
+        case .betweenDate: return sanitizeDateRange(value)
+        }
+    }
+
+    private static func sanitizeSingleString(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let s = v["string"] as? String else { return nil }
+        return .singleString(s)
+    }
+
+    private static func sanitizeListString(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let raw = v["list"] as? [Any?] else { return nil }
+        var out: [String] = []
+        for item in raw {
+            guard let s = item as? String else { return nil }
+            out.append(s)
+        }
+        return .listString(out)
+    }
+
+    private static func sanitizeSingleNumber(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let n = coerceNumber(v["number"] ?? nil) else { return nil }
+        return .singleNumber(n)
+    }
+
+    private static func sanitizeNumericRange(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let s = coerceNumber(v["start"] ?? nil),
+              let e = coerceNumber(v["end"] ?? nil) else { return nil }
+        return .numericRange(start: s, end: e)
+    }
+
+    private static func sanitizeSingleBoolean(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let b = v["boolean"] as? Bool else { return nil }
+        return .singleBoolean(b)
+    }
+
+    private static func sanitizeSingleDate(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let d = coerceDate(v["date"] ?? nil) else { return nil }
+        return .singleDate(d)
+    }
+
+    private static func sanitizeDateRange(_ v: [String: Any?]) -> SanitizedPayload? {
+        guard let s = coerceDate(v["start"] ?? nil),
+              let e = coerceDate(v["end"] ?? nil) else { return nil }
+        return .dateRange(start: s, end: e)
+    }
+}
+
+/// Type coercion helpers used by both `SanitizerResolver` (to parse condition
+/// payloads) and `OperationResolver` (to coerce attribute values pulled from the
+/// JWT/custom map).
+///
+/// Mirror web's strictness as closely as we can — `Bool` is intentionally NOT
+/// coerced into a number (Swift bridges `Bool` through `NSNumber`, which lets it
+/// pass an `as? Double` cast — guard against that explicitly).
+func coerceNumber(_ value: Any?) -> Double? {
+    if value is Bool { return nil }
+    if let d = value as? Double { return d }
+    if let i = value as? Int { return Double(i) }
+    if let i = value as? Int64 { return Double(i) }
+    if let f = value as? Float { return Double(f) }
+    if let n = value as? NSNumber {
+        // NSNumber bridges everything including Bool — re-check to defend against
+        // a Bool that snuck through the `is Bool` guard above (e.g., from an array).
+        if CFGetTypeID(n) == CFBooleanGetTypeID() { return nil }
+        return n.doubleValue
+    }
+    return nil
+}
+
+private let isoFormatters: [DateFormatter] = {
+    let patterns = [
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd"
+    ]
+    return patterns.map { pattern in
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = pattern
+        return f
+    }
+}()
+
+func coerceDate(_ value: Any?) -> Date? {
+    if let d = value as? Date { return d }
+    if let n = coerceNumber(value) { return Date(timeIntervalSince1970: n / 1000) }
+    if let s = value as? String {
+        for fmt in isoFormatters {
+            if let d = fmt.date(from: s) { return d }
+        }
+    }
+    return nil
+}
+
+enum OperationResolver {
+    /// Returns a handler `(Any?) -> Bool` for the given (operation, payload). Returns
+    /// `nil` when the pair is mismatched — treated as "condition is false" by
+    /// `ConditionEvaluator`.
+    static func resolve(_ operation: FronteggOperation, payload: SanitizedPayload) -> ((Any?) -> Bool)? {
+        switch operation {
+        case .startsWith:
+            guard case .listString(let list) = payload else { return nil }
+            return { attr in (attr as? String).map { a in list.contains(where: { a.hasPrefix($0) }) } ?? false }
+
+        case .endsWith:
+            guard case .listString(let list) = payload else { return nil }
+            return { attr in (attr as? String).map { a in list.contains(where: { a.hasSuffix($0) }) } ?? false }
+
+        case .contains:
+            guard case .listString(let list) = payload else { return nil }
+            return { attr in (attr as? String).map { a in list.contains(where: { a.contains($0) }) } ?? false }
+
+        case .inList:
+            guard case .listString(let list) = payload else { return nil }
+            return { attr in (attr as? String).map { list.contains($0) } ?? false }
+
+        case .matches:
+            guard case .singleString(let s) = payload else { return nil }
+            guard let regex = try? NSRegularExpression(pattern: s, options: []) else { return { _ in false } }
+            return { attr in
+                guard let str = attr as? String else { return false }
+                let range = NSRange(str.startIndex..<str.endIndex, in: str)
+                return regex.firstMatch(in: str, options: [], range: range) != nil
+            }
+
+        case .equal: return numericPredicate(payload) { a, n in a == n }
+        case .greaterThan: return numericPredicate(payload) { a, n in a > n }
+        case .greaterThanEqual: return numericPredicate(payload) { a, n in a >= n }
+        case .lesserThan: return numericPredicate(payload) { a, n in a < n }
+        case .lesserThanEqual: return numericPredicate(payload) { a, n in a <= n }
+        case .betweenNumeric:
+            guard case .numericRange(let s, let e) = payload else { return nil }
+            return { attr in coerceNumber(attr).map { $0 >= s && $0 <= e } ?? false }
+
+        case .is:
+            guard case .singleBoolean(let b) = payload else { return nil }
+            return { attr in (attr as? Bool) == b }
+
+        case .on: return datePredicate(payload) { a, d in a.timeIntervalSince1970 == d.timeIntervalSince1970 }
+        case .onOrAfter: return datePredicate(payload) { a, d in a.timeIntervalSince1970 >= d.timeIntervalSince1970 }
+        case .onOrBefore: return datePredicate(payload) { a, d in a.timeIntervalSince1970 <= d.timeIntervalSince1970 }
+        case .betweenDate:
+            guard case .dateRange(let s, let e) = payload else { return nil }
+            return { attr in
+                coerceDate(attr).map { $0.timeIntervalSince1970 >= s.timeIntervalSince1970 && $0.timeIntervalSince1970 <= e.timeIntervalSince1970 } ?? false
+            }
+        }
+    }
+
+    private static func numericPredicate(_ payload: SanitizedPayload, _ compare: @escaping (Double, Double) -> Bool) -> ((Any?) -> Bool)? {
+        guard case .singleNumber(let n) = payload else { return nil }
+        return { attr in coerceNumber(attr).map { compare($0, n) } ?? false }
+    }
+
+    private static func datePredicate(_ payload: SanitizedPayload, _ compare: @escaping (Date, Date) -> Bool) -> ((Any?) -> Bool)? {
+        guard case .singleDate(let d) = payload else { return nil }
+        return { attr in coerceDate(attr).map { compare($0, d) } ?? false }
+    }
+}

--- a/Sources/FronteggSwift/entitlements/PermissionMatcher.swift
+++ b/Sources/FronteggSwift/entitlements/PermissionMatcher.swift
@@ -1,0 +1,48 @@
+//
+//  PermissionMatcher.swift
+//  FronteggSwift
+//
+//  Port of `checkPermission` from @frontegg/entitlements-javascript-commons.
+//
+
+import Foundation
+
+enum PermissionMatcher {
+    /// The server returns granted permissions as concrete strings OR wildcard
+    /// patterns (e.g. `fe.secure.*`); the host app asks about a concrete required
+    /// permission (e.g. `fe.secure.read.users`). Match if any granted key, when its
+    /// wildcards are turned into `.*`, regex-matches the requested key.
+    ///
+    /// The regex is anchored — `^…$` — so `fe.secure.*` does NOT match
+    /// `prefix.fe.secure.x`. Dots are escaped to literals; `*` is the only
+    /// wildcard.
+    static func hasPermission(_ granted: [String: Bool], required: String) -> Bool {
+        let truthy = granted.filter { $0.value }.map { $0.key }
+        for key in truthy where matches(pattern: key, value: required) {
+            return true
+        }
+        return false
+    }
+
+    private static func matches(pattern: String, value: String) -> Bool {
+        var escaped = "^"
+        for ch in pattern {
+            switch ch {
+            case "*": escaped += ".*"
+            case ".": escaped += "\\."
+            // Defensive — escape other regex metacharacters so a malformed permission
+            // key can't ReDoS the SDK.
+            case "+", "?", "(", ")", "[", "]", "{", "}", "|", "^", "$", "\\":
+                escaped.append("\\")
+                escaped.append(ch)
+            default: escaped.append(ch)
+            }
+        }
+        escaped += "$"
+        guard let regex = try? NSRegularExpression(pattern: escaped, options: [.dotMatchesLineSeparators]) else {
+            return false
+        }
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return regex.firstMatch(in: value, options: [], range: range) != nil
+    }
+}

--- a/Sources/FronteggSwift/entitlements/UserEntitlementsContext.swift
+++ b/Sources/FronteggSwift/entitlements/UserEntitlementsContext.swift
@@ -1,0 +1,214 @@
+//
+//  UserEntitlementsContext.swift
+//  FronteggSwift
+//
+//  Port of the UserEntitlementsContext shape from
+//  @frontegg/entitlements-javascript-commons (the canonical evaluator the web SDK
+//  uses). Mirrors the v2 /frontegg/entitlements/api/v2/user-entitlements response.
+//
+//  Pre-fix the mobile SDK only kept the `features` map's *keys* and discarded
+//  everything else — that's why getFeatureEntitlements(featureKey: "sso") returned
+//  isEntitled = true regardless of plan defaultTreatment, expiry, or feature flags.
+//  Storing the full structure lets us run the same evaluator chain as web.
+//
+
+import Foundation
+
+public struct UserEntitlementsContext: Equatable {
+    public let features: [String: FeatureDetail]
+    public let plans: [String: Plan]
+    public let permissions: [String: Bool]
+
+    public init(features: [String: FeatureDetail], plans: [String: Plan], permissions: [String: Bool]) {
+        self.features = features
+        self.plans = plans
+        self.permissions = permissions
+    }
+}
+
+public struct FeatureDetail: Equatable {
+    public let planIds: [String]
+    /// `nil` when this feature is not directly assigned to the user (only reachable
+    /// via a plan or feature flag); `NO_EXPIRATION_TIME` when assigned permanently;
+    /// otherwise an epoch-millis timestamp.
+    public let expireTime: Int64?
+    public let linkedPermissions: [String]
+    public let featureFlag: FeatureFlag?
+
+    public init(planIds: [String], expireTime: Int64?, linkedPermissions: [String], featureFlag: FeatureFlag?) {
+        self.planIds = planIds
+        self.expireTime = expireTime
+        self.linkedPermissions = linkedPermissions
+        self.featureFlag = featureFlag
+    }
+
+    /// Sentinel for "directly assigned, never expires". Matches the web SDK's
+    /// `NO_EXPIRATION_TIME` constant.
+    public static let NO_EXPIRATION_TIME: Int64 = -1
+}
+
+public struct Plan: Equatable {
+    public let defaultTreatment: Treatment
+    public let rules: [Rule]?
+
+    public init(defaultTreatment: Treatment, rules: [Rule]? = nil) {
+        self.defaultTreatment = defaultTreatment
+        self.rules = rules
+    }
+}
+
+public struct FeatureFlag: Equatable {
+    public let on: Bool
+    public let offTreatment: Treatment
+    public let defaultTreatment: Treatment
+    public let rules: [Rule]?
+
+    public init(on: Bool, offTreatment: Treatment, defaultTreatment: Treatment, rules: [Rule]? = nil) {
+        self.on = on
+        self.offTreatment = offTreatment
+        self.defaultTreatment = defaultTreatment
+        self.rules = rules
+    }
+}
+
+public struct Rule: Equatable {
+    public let conditionLogic: ConditionLogic
+    public let conditions: [Condition]
+    public let treatment: Treatment
+
+    public init(conditionLogic: ConditionLogic, conditions: [Condition], treatment: Treatment) {
+        self.conditionLogic = conditionLogic
+        self.conditions = conditions
+        self.treatment = treatment
+    }
+}
+
+public enum ConditionLogic: String, Equatable {
+    case and
+}
+
+public enum Treatment: String, Equatable {
+    case `true` = "true"
+    case `false` = "false"
+}
+
+public struct Condition: Equatable {
+    public let attribute: String
+    public let negate: Bool
+    public let op: FronteggOperation
+    /// Raw value shape varies by operation kind (e.g. `["string": "abc"]` for
+    /// `matches`, `["list": [...]]` for `in_list`, `["number": 42]` for numeric ops,
+    /// `["start": ..., "end": ...]` for ranges, `["boolean": true]` for `is`,
+    /// `["date": "..."]` for date ops). The matching sanitizer is responsible for
+    /// narrowing to the expected payload.
+    public let value: [String: AnyEquatable]
+
+    public init(attribute: String, negate: Bool, op: FronteggOperation, value: [String: Any]) {
+        self.attribute = attribute
+        self.negate = negate
+        self.op = op
+        self.value = value.mapValues { AnyEquatable($0) }
+    }
+
+    /// Convenience for accessing the underlying raw value as `Any?` for the
+    /// sanitizer layer.
+    public func rawValue() -> [String: Any?] {
+        var out: [String: Any?] = [:]
+        for (k, v) in value {
+            out[k] = v.value
+        }
+        return out
+    }
+
+    public static func == (lhs: Condition, rhs: Condition) -> Bool {
+        lhs.attribute == rhs.attribute &&
+            lhs.negate == rhs.negate &&
+            lhs.op == rhs.op &&
+            lhs.value == rhs.value
+    }
+}
+
+/// Mirrors `OperationEnum` from `@frontegg/entitlements-javascript-commons`. Raw
+/// values match the JSON the server emits.
+public enum FronteggOperation: String, Equatable {
+    // String
+    case inList = "in_list"
+    case startsWith = "starts_with"
+    case endsWith = "ends_with"
+    case contains
+    case matches
+
+    // Numeric
+    case equal
+    case greaterThan = "greater_than"
+    case greaterThanEqual = "greater_than_equal"
+    case lesserThan = "lower_than"
+    case lesserThanEqual = "lower_than_equal"
+    case betweenNumeric = "between_numeric"
+
+    // Boolean
+    case `is`
+
+    // Date
+    case on
+    case betweenDate = "between_date"
+    case onOrAfter = "on_or_after"
+    case onOrBefore = "on_or_before"
+}
+
+/// Pair of `isEntitled` flag plus, when negative, a `NotEntitledJustification` code.
+public struct EntitlementResult: Equatable {
+    public let isEntitled: Bool
+    public let justification: String?
+
+    public init(isEntitled: Bool, justification: String? = nil) {
+        self.isEntitled = isEntitled
+        self.justification = justification
+    }
+}
+
+public struct Attributes {
+    public let custom: [String: Any?]?
+    public let jwt: [String: Any?]?
+
+    public init(custom: [String: Any?]? = nil, jwt: [String: Any?]? = nil) {
+        self.custom = custom
+        self.jwt = jwt
+    }
+}
+
+/// Type-erased wrapper that lets condition value dictionaries participate in
+/// `Equatable` (needed because `[String: Any]` is not `Equatable`). Compares by
+/// structural equality of the underlying `Any?`.
+public struct AnyEquatable: Equatable {
+    public let value: Any?
+
+    public init(_ value: Any?) {
+        self.value = value
+    }
+
+    public static func == (lhs: AnyEquatable, rhs: AnyEquatable) -> Bool {
+        return anyEqual(lhs.value, rhs.value)
+    }
+}
+
+private func anyEqual(_ a: Any?, _ b: Any?) -> Bool {
+    switch (a, b) {
+    case (nil, nil): return true
+    case let (x as String, y as String): return x == y
+    case let (x as Bool, y as Bool): return x == y
+    case let (x as Int, y as Int): return x == y
+    case let (x as Double, y as Double): return x == y
+    case let (x as Date, y as Date): return x == y
+    case let (x as [Any?], y as [Any?]):
+        guard x.count == y.count else { return false }
+        for i in 0..<x.count where !anyEqual(x[i], y[i]) { return false }
+        return true
+    case let (x as [String: Any?], y as [String: Any?]):
+        guard x.keys.sorted() == y.keys.sorted() else { return false }
+        for (k, vx) in x where !anyEqual(vx, y[k] ?? nil) { return false }
+        return true
+    default:
+        return false
+    }
+}

--- a/Sources/FronteggSwift/entitlements/UserEntitlementsParser.swift
+++ b/Sources/FronteggSwift/entitlements/UserEntitlementsParser.swift
@@ -1,0 +1,144 @@
+//
+//  UserEntitlementsParser.swift
+//  FronteggSwift
+//
+//  Lenient parser for the `/frontegg/entitlements/api/v2/user-entitlements` JSON
+//  response. Mirrors the shape consumed by
+//  @frontegg/entitlements-javascript-commons.
+//
+//  Lenient on purpose — the SDK ships ahead of server-side schema changes. Unknown
+//  keys are ignored; malformed sub-objects cause that sub-object to be dropped
+//  rather than failing the whole parse.
+//
+
+import Foundation
+
+enum UserEntitlementsParser {
+
+    static func parse(_ json: [String: Any]) -> UserEntitlementsContext {
+        let features = parseFeatures(json["features"] as? [String: Any])
+        let plans = parsePlans(json["plans"] as? [String: Any])
+        let permissions = parsePermissions(json["permissions"] as? [String: Any])
+        return UserEntitlementsContext(features: features, plans: plans, permissions: permissions)
+    }
+
+    private static func parseFeatures(_ node: [String: Any]?) -> [String: FeatureDetail] {
+        guard let node = node else { return [:] }
+        var out: [String: FeatureDetail] = [:]
+        for (key, value) in node {
+            guard let obj = value as? [String: Any] else { continue }
+            let planIds = (obj["planIds"] as? [Any]).flatMap { asStringList($0) } ?? []
+            let expireTime = asNullableInt64(obj["expireTime"])
+            let linkedPermissions = (obj["linkedPermissions"] as? [Any]).flatMap { asStringList($0) } ?? []
+            let featureFlag = parseFeatureFlag(obj["featureFlag"] as? [String: Any])
+            out[key] = FeatureDetail(
+                planIds: planIds,
+                expireTime: expireTime,
+                linkedPermissions: linkedPermissions,
+                featureFlag: featureFlag
+            )
+        }
+        return out
+    }
+
+    private static func parsePlans(_ node: [String: Any]?) -> [String: Plan] {
+        guard let node = node else { return [:] }
+        var out: [String: Plan] = [:]
+        for (key, value) in node {
+            guard let obj = value as? [String: Any] else { continue }
+            // `defaultTreatment` is required for a plan to be meaningful; drop the
+            // plan entirely if it's missing rather than guessing.
+            guard let treatmentRaw = obj["defaultTreatment"] as? String,
+                  let defaultTreatment = Treatment(rawValue: treatmentRaw) else { continue }
+            let rules = parseRules(obj["rules"] as? [Any])
+            out[key] = Plan(defaultTreatment: defaultTreatment, rules: rules)
+        }
+        return out
+    }
+
+    private static func parsePermissions(_ node: [String: Any]?) -> [String: Bool] {
+        guard let node = node else { return [:] }
+        var out: [String: Bool] = [:]
+        for (key, value) in node {
+            // JSONSerialization gives Bool through NSNumber; filter to actual Bool.
+            if let n = value as? NSNumber, CFGetTypeID(n) == CFBooleanGetTypeID() {
+                out[key] = n.boolValue
+            }
+        }
+        return out
+    }
+
+    private static func parseFeatureFlag(_ node: [String: Any]?) -> FeatureFlag? {
+        guard let node = node else { return nil }
+        guard let on = (node["on"] as? NSNumber).flatMap({ n in CFGetTypeID(n) == CFBooleanGetTypeID() ? n.boolValue : nil }),
+              let offTreatmentRaw = node["offTreatment"] as? String,
+              let offTreatment = Treatment(rawValue: offTreatmentRaw),
+              let defaultTreatmentRaw = node["defaultTreatment"] as? String,
+              let defaultTreatment = Treatment(rawValue: defaultTreatmentRaw) else { return nil }
+        let rules = parseRules(node["rules"] as? [Any])
+        return FeatureFlag(
+            on: on,
+            offTreatment: offTreatment,
+            defaultTreatment: defaultTreatment,
+            rules: rules
+        )
+    }
+
+    private static func parseRules(_ node: [Any]?) -> [Rule]? {
+        guard let node = node else { return nil }
+        var out: [Rule] = []
+        for element in node {
+            guard let obj = element as? [String: Any],
+                  let rule = parseRule(obj) else { continue }
+            out.append(rule)
+        }
+        return out
+    }
+
+    private static func parseRule(_ obj: [String: Any]) -> Rule? {
+        guard let logicRaw = obj["conditionLogic"] as? String,
+              let logic = ConditionLogic(rawValue: logicRaw),
+              let treatmentRaw = obj["treatment"] as? String,
+              let treatment = Treatment(rawValue: treatmentRaw),
+              let conditionsNode = obj["conditions"] as? [Any] else { return nil }
+        var conditions: [Condition] = []
+        for c in conditionsNode {
+            guard let cObj = c as? [String: Any],
+                  let condition = parseCondition(cObj) else { continue }
+            conditions.append(condition)
+        }
+        if conditions.isEmpty { return nil }
+        return Rule(conditionLogic: logic, conditions: conditions, treatment: treatment)
+    }
+
+    private static func parseCondition(_ obj: [String: Any]) -> Condition? {
+        guard let attribute = obj["attribute"] as? String,
+              let opRaw = obj["op"] as? String,
+              let op = FronteggOperation(rawValue: opRaw),
+              let valueNode = obj["value"] as? [String: Any] else { return nil }
+        let negate = (obj["negate"] as? Bool) ?? false
+        return Condition(attribute: attribute, negate: negate, op: op, value: valueNode)
+    }
+
+    private static func asStringList(_ raw: [Any]) -> [String] {
+        var out: [String] = []
+        for e in raw {
+            guard let s = e as? String else { continue }
+            out.append(s)
+        }
+        return out
+    }
+
+    private static func asNullableInt64(_ value: Any?) -> Int64? {
+        guard let value = value, !(value is NSNull) else { return nil }
+        if let i = value as? Int { return Int64(i) }
+        if let i = value as? Int64 { return i }
+        if let i = value as? Int32 { return Int64(i) }
+        if let d = value as? Double { return Int64(d) }
+        if let n = value as? NSNumber {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() { return nil }
+            return n.int64Value
+        }
+        return nil
+    }
+}

--- a/Sources/FronteggSwift/models/Entitlement.swift
+++ b/Sources/FronteggSwift/models/Entitlement.swift
@@ -19,3 +19,19 @@ public enum EntitledToOptions {
     case featureKey(String)
     case permissionKey(String)
 }
+
+/// Canonical justification codes mirrored from
+/// `@frontegg/entitlements-javascript-commons` plus the mobile-specific cases the
+/// SDK has historically returned.
+///
+/// The web SDK exposes `MISSING_FEATURE`, `MISSING_PERMISSION`, and `BUNDLE_EXPIRED`.
+/// Mobile additionally needs `NOT_AUTHENTICATED` and `ENTITLEMENTS_DISABLED` to
+/// describe SDK-side preconditions that don't exist on web (where the entitlements
+/// context is always available synchronously after login).
+public enum NotEntitledJustification {
+    public static let NOT_AUTHENTICATED = "NOT_AUTHENTICATED"
+    public static let ENTITLEMENTS_DISABLED = "ENTITLEMENTS_DISABLED"
+    public static let MISSING_FEATURE = "MISSING_FEATURE"
+    public static let MISSING_PERMISSION = "MISSING_PERMISSION"
+    public static let BUNDLE_EXPIRED = "BUNDLE_EXPIRED"
+}

--- a/Sources/FronteggSwift/services/Entitlements.swift
+++ b/Sources/FronteggSwift/services/Entitlements.swift
@@ -5,18 +5,30 @@
 
 import Foundation
 
-private struct UserEntitlementsResponse: Decodable {
-    let features: [String: FeatureDetail]?
-    let permissions: [String: Bool]?
-
-    struct FeatureDetail: Decodable {}
-}
-
-public struct EntitlementState {
+public struct EntitlementState: Equatable {
+    /// Catalog of feature keys in the most recent `/user-entitlements` response.
+    /// Kept for backwards compatibility with host apps that render counts/debug
+    /// surfaces. **NOT** the verdict — the verdict goes through `checkFeature` /
+    /// `checkPermission`, driven off `context`.
     public let featureKeys: Set<String>
+    /// Permission keys with `value = true` in the response. Backwards-compat only;
+    /// see `featureKeys` note above.
     public let permissionKeys: Set<String>
+    /// Structured form used by the evaluators. `nil` when entitlements haven't
+    /// been loaded yet or the load failed.
+    public let context: UserEntitlementsContext?
 
-    public static let empty = EntitlementState(featureKeys: [], permissionKeys: [])
+    public init(
+        featureKeys: Set<String>,
+        permissionKeys: Set<String>,
+        context: UserEntitlementsContext? = nil
+    ) {
+        self.featureKeys = featureKeys
+        self.permissionKeys = permissionKeys
+        self.context = context
+    }
+
+    public static let empty = EntitlementState(featureKeys: [], permissionKeys: [], context: nil)
 }
 
 public final class Entitlements {
@@ -76,19 +88,32 @@ public final class Entitlements {
                 logger.warning("Failed to load user entitlements: HTTP \(code)")
                 return false
             }
-            let parsed = try JSONDecoder().decode(UserEntitlementsResponse.self, from: data)
-
-            var featureKeys = Set<String>()
-            var permissionKeys = Set<String>()
-
-            if let features = parsed.features {
-                featureKeys.formUnion(features.keys)
+            // Parse the full UserEntitlementsContext (features w/ planIds /
+            // expireTime / linkedPermissions / featureFlag, plans, permissions).
+            // Pre-fix the SDK only kept the feature keys + truthy permissions and
+            // threw away everything needed to make an actual entitlement decision
+            // (FR-24821).
+            guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                logger.warning("Failed to parse user-entitlements response as JSON object")
+                return false
             }
-            if let permissions = parsed.permissions {
-                permissionKeys.formUnion(permissions.filter { $0.value }.map(\.key))
-            }
+            let context = UserEntitlementsParser.parse(json)
 
-            setState(EntitlementState(featureKeys: featureKeys, permissionKeys: permissionKeys))
+            // Keep populating featureKeys/permissionKeys for backwards compat with
+            // host apps that read them off `auth.entitlements.state` (e.g. the
+            // demo's "Cached: N feature(s), M permission(s)" summary).
+            // featureKeys is the catalog of feature keys seen in the response.
+            // permissionKeys is the set of keys with value=true.
+            let featureKeys = Set(context.features.keys)
+            let permissionKeys = Set(context.permissions.filter { $0.value }.map { $0.key })
+
+            setState(
+                EntitlementState(
+                    featureKeys: featureKeys,
+                    permissionKeys: permissionKeys,
+                    context: context
+                )
+            )
             logger.info("Loaded entitlements: \(featureKeys.count) feature(s), \(permissionKeys.count) permission(s)")
             return true
         } catch {
@@ -101,19 +126,23 @@ public final class Entitlements {
         setState(.empty, hasLoaded: false)
     }
 
-    public func checkFeature(featureKey: String) -> Entitlement {
+    /// Evaluates `featureKey` against the cached `UserEntitlementsContext` using
+    /// the full decision chain (direct entitlement + feature flag + plan targeting
+    /// rules). `attributes` carries JWT claims and any host-app custom attributes
+    /// used by rule conditions — see `AttributesPreparer`.
+    public func checkFeature(featureKey: String, attributes: Attributes = Attributes()) -> Entitlement {
         guard enabled else {
-            return Entitlement(isEntitled: false, justification: "ENTITLEMENTS_DISABLED")
+            return Entitlement(isEntitled: false, justification: NotEntitledJustification.ENTITLEMENTS_DISABLED)
         }
-        let entitled = state.featureKeys.contains(featureKey)
-        return Entitlement(isEntitled: entitled, justification: entitled ? nil : "MISSING_FEATURE")
+        let result = IsEntitledToFeature.evaluate(featureKey, context: state.context, attributes: attributes)
+        return Entitlement(isEntitled: result.isEntitled, justification: result.justification)
     }
 
-    public func checkPermission(permissionKey: String) -> Entitlement {
+    public func checkPermission(permissionKey: String, attributes: Attributes = Attributes()) -> Entitlement {
         guard enabled else {
-            return Entitlement(isEntitled: false, justification: "ENTITLEMENTS_DISABLED")
+            return Entitlement(isEntitled: false, justification: NotEntitledJustification.ENTITLEMENTS_DISABLED)
         }
-        let entitled = state.permissionKeys.contains(permissionKey)
-        return Entitlement(isEntitled: entitled, justification: entitled ? nil : "MISSING_PERMISSION")
+        let result = IsEntitledToPermission.evaluate(permissionKey, context: state.context, attributes: attributes)
+        return Entitlement(isEntitled: result.isEntitled, justification: result.justification)
     }
 }

--- a/Sources/FronteggSwift/services/Entitlements.swift
+++ b/Sources/FronteggSwift/services/Entitlements.swift
@@ -97,6 +97,18 @@ public final class Entitlements {
                 logger.warning("Failed to parse user-entitlements response as JSON object")
                 return false
             }
+
+            // Diagnostic logging — full RAW response body. Tagged `[ENT-DEBUG]` so
+            // it's easy to filter the Xcode console for entitlement diagnostics
+            // while triaging FR-24821-style "verdict doesn't match web" reports.
+            // The host app's logger is the same instance used for everything else
+            // in the SDK; if the host app sets log level below `.info` (or the
+            // FronteggApp `logLevel` config is `.debug` / `.info`) this surfaces
+            // automatically.
+            if let rawString = String(data: data, encoding: .utf8) {
+                logger.info("[ENT-DEBUG] RAW /user-entitlements response: \(rawString)")
+            }
+
             let context = UserEntitlementsParser.parse(json)
 
             // Keep populating featureKeys/permissionKeys for backwards compat with
@@ -115,6 +127,17 @@ public final class Entitlements {
                 )
             )
             logger.info("Loaded entitlements: \(featureKeys.count) feature(s), \(permissionKeys.count) permission(s)")
+            logger.info("[ENT-DEBUG] Parsed context — features: \(context.features.count), plans: \(context.plans.count), permissions: \(context.permissions.count)")
+            for (key, detail) in context.features {
+                let planIdsStr = detail.planIds.isEmpty ? "[]" : "[\(detail.planIds.joined(separator: ","))]"
+                let expireStr = detail.expireTime.map { "\($0)" } ?? "nil"
+                let flagStr = detail.featureFlag.map { "on=\($0.on) off=\($0.offTreatment.rawValue) default=\($0.defaultTreatment.rawValue) rules=\($0.rules?.count ?? 0)" } ?? "nil"
+                logger.info("[ENT-DEBUG]   feature[\(key)]: planIds=\(planIdsStr) expireTime=\(expireStr) featureFlag=\(flagStr) linkedPermissions=\(detail.linkedPermissions)")
+            }
+            for (key, plan) in context.plans {
+                let rulesStr = plan.rules?.count ?? 0
+                logger.info("[ENT-DEBUG]   plan[\(key)]: defaultTreatment=\(plan.defaultTreatment.rawValue) rules=\(rulesStr)")
+            }
             return true
         } catch {
             logger.warning("Failed to load user entitlements: \(error)")
@@ -135,6 +158,7 @@ public final class Entitlements {
             return Entitlement(isEntitled: false, justification: NotEntitledJustification.ENTITLEMENTS_DISABLED)
         }
         let result = IsEntitledToFeature.evaluate(featureKey, context: state.context, attributes: attributes)
+        logCheckTrace(kind: "feature", key: featureKey, attributes: attributes, result: result)
         return Entitlement(isEntitled: result.isEntitled, justification: result.justification)
     }
 
@@ -143,6 +167,45 @@ public final class Entitlements {
             return Entitlement(isEntitled: false, justification: NotEntitledJustification.ENTITLEMENTS_DISABLED)
         }
         let result = IsEntitledToPermission.evaluate(permissionKey, context: state.context, attributes: attributes)
+        logCheckTrace(kind: "permission", key: permissionKey, attributes: attributes, result: result)
         return Entitlement(isEntitled: result.isEntitled, justification: result.justification)
+    }
+
+    /// Diagnostic trace for `getFeatureEntitlements` / `getPermissionEntitlements`.
+    /// Shows the prepared attribute bag (so the caller can confirm
+    /// `frontegg.tenantId` / `frontegg.email` / etc. actually came through from the
+    /// JWT) and the verdict. Tagged `[ENT-DEBUG]` for easy Xcode-console filtering.
+    /// Sensitive claims (email, tenantId) only appear in your own test app's
+    /// debug log, never leaving the device unless you copy them.
+    private func logCheckTrace(kind: String, key: String, attributes: Attributes, result: EntitlementResult) {
+        let prepared = AttributesPreparer.prepare(attributes)
+        let attributeSummary = prepared
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value ?? "nil")" }
+            .joined(separator: ", ")
+        let contextStatus: String
+        if let ctx = state.context {
+            contextStatus = "features=\(ctx.features.count) plans=\(ctx.plans.count) permissions=\(ctx.permissions.count)"
+        } else {
+            contextStatus = "context=nil"
+        }
+        logger.info("[ENT-DEBUG] check\(kind)(\"\(key)\") → isEntitled=\(result.isEntitled) justification=\(result.justification ?? "nil")")
+        logger.info("[ENT-DEBUG]   context: \(contextStatus)")
+        logger.info("[ENT-DEBUG]   attributes: {\(attributeSummary)}")
+        // Print the relevant slice of the context for THIS feature/permission so
+        // the trace is self-contained — no need to cross-reference the load log.
+        if kind == "feature", let ctx = state.context, let feature = ctx.features[key] {
+            let planIdsStr = feature.planIds.isEmpty ? "[]" : "[\(feature.planIds.joined(separator: ","))]"
+            let expireStr = feature.expireTime.map { "\($0)" } ?? "nil"
+            let flagStr = feature.featureFlag.map { "on=\($0.on) off=\($0.offTreatment.rawValue) default=\($0.defaultTreatment.rawValue) rules=\($0.rules?.count ?? 0)" } ?? "nil"
+            logger.info("[ENT-DEBUG]   feature slice: planIds=\(planIdsStr) expireTime=\(expireStr) featureFlag=\(flagStr) linkedPermissions=\(feature.linkedPermissions)")
+            for planId in feature.planIds {
+                if let plan = ctx.plans[planId] {
+                    logger.info("[ENT-DEBUG]     linked plan[\(planId)]: defaultTreatment=\(plan.defaultTreatment.rawValue) rules=\(plan.rules?.count ?? 0)")
+                } else {
+                    logger.info("[ENT-DEBUG]     linked plan[\(planId)]: MISSING from plans map")
+                }
+            }
+        }
     }
 }

--- a/Tests/FronteggSwiftTests/EntitlementEvaluatorsTests.swift
+++ b/Tests/FronteggSwiftTests/EntitlementEvaluatorsTests.swift
@@ -1,0 +1,564 @@
+//
+//  EntitlementEvaluatorsTests.swift
+//  FronteggSwiftTests
+//
+//  Port of the Android entitlement evaluator tests. Tests are organized by
+//  evaluator layer (condition → rule → plan / featureFlag → feature / permission)
+//  with the FR-24821 customer reproduction at the top of the feature suite.
+//
+
+import XCTest
+@testable import FronteggSwift
+
+final class ConditionEvaluatorTests: XCTestCase {
+
+    private func cond(
+        attribute: String,
+        op: FronteggOperation,
+        value: [String: Any],
+        negate: Bool = false
+    ) -> Condition {
+        Condition(attribute: attribute, negate: negate, op: op, value: value)
+    }
+
+    // MARK: - String
+
+    func test_inList_matches() {
+        let c = cond(attribute: "frontegg.email", op: .inList, value: ["list": ["a@x.com", "b@x.com"]])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["frontegg.email": "a@x.com"]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["frontegg.email": "c@x.com"]))
+    }
+
+    func test_inList_malformed_payload_returns_false() {
+        // `list` element types don't match — sanitizer returns nil → condition false.
+        let c = cond(attribute: "k", op: .inList, value: ["list": ["a", 1]])
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "a"]))
+    }
+
+    func test_startsWith_endsWith_contains() {
+        let starts = cond(attribute: "k", op: .startsWith, value: ["list": ["foo", "bar"]])
+        XCTAssertTrue(ConditionEvaluator.evaluate(starts, attributes: ["k": "foobar"]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(starts, attributes: ["k": "barbaz"]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(starts, attributes: ["k": "baz"]))
+
+        let ends = cond(attribute: "k", op: .endsWith, value: ["list": ["xyz"]])
+        XCTAssertTrue(ConditionEvaluator.evaluate(ends, attributes: ["k": "abcxyz"]))
+
+        let contains = cond(attribute: "k", op: .contains, value: ["list": ["ll"]])
+        XCTAssertTrue(ConditionEvaluator.evaluate(contains, attributes: ["k": "hello"]))
+    }
+
+    func test_matches_regex_semantics() {
+        let c = cond(attribute: "k", op: .matches, value: ["string": "^foo.*bar$"])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": "foo-x-bar"]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "foo-x-baz"]))
+    }
+
+    func test_matches_malformed_regex_returns_false() {
+        // Unmatched `(` — NSRegularExpression throws; swallow and return false rather
+        // than crash the host app's entitlement check.
+        let c = cond(attribute: "k", op: .matches, value: ["string": "("])
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "anything"]))
+    }
+
+    // MARK: - Numeric
+
+    func test_equal_across_int_and_double() {
+        let c = cond(attribute: "k", op: .equal, value: ["number": 42])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": 42]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": Int64(42)]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": 42.0]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": 43]))
+    }
+
+    func test_betweenNumeric_inclusive() {
+        let c = cond(attribute: "k", op: .betweenNumeric, value: ["start": 10, "end": 20])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": 10]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": 15]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": 20]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": 21]))
+    }
+
+    func test_greaterThan_and_lesserThanEqual() {
+        let gt = cond(attribute: "k", op: .greaterThan, value: ["number": 5])
+        XCTAssertTrue(ConditionEvaluator.evaluate(gt, attributes: ["k": 6]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(gt, attributes: ["k": 5]))
+        let lte = cond(attribute: "k", op: .lesserThanEqual, value: ["number": 5])
+        XCTAssertTrue(ConditionEvaluator.evaluate(lte, attributes: ["k": 5]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(lte, attributes: ["k": 6]))
+    }
+
+    // MARK: - Boolean
+
+    func test_boolean_is_strict_rejects_string_true() {
+        let c = cond(attribute: "k", op: .is, value: ["boolean": true])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": true]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": false]))
+        // Web compares with `===`. Match that — string "true" is NOT Bool true.
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "true"]))
+    }
+
+    // MARK: - Date
+
+    func test_onOrAfter_with_iso_string_attribute() {
+        let c = cond(attribute: "k", op: .onOrAfter, value: ["date": "2026-01-01T00:00:00Z"])
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": "2026-06-01T00:00:00Z"]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "2025-12-31T00:00:00Z"]))
+    }
+
+    func test_betweenDate_inclusive() {
+        let c = cond(
+            attribute: "k",
+            op: .betweenDate,
+            value: ["start": "2026-01-01T00:00:00Z", "end": "2026-12-31T00:00:00Z"]
+        )
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": "2026-06-15T00:00:00Z"]))
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "2027-01-01T00:00:00Z"]))
+    }
+
+    // MARK: - Edge cases
+
+    func test_missing_attribute_is_false_even_with_negate() {
+        let c = cond(attribute: "absent", op: .is, value: ["boolean": true], negate: true)
+        // Web short-circuits before negate: absent attribute is unconditionally false.
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["present": true]))
+    }
+
+    func test_negate_inverts_normally_true_match() {
+        let c = cond(attribute: "k", op: .is, value: ["boolean": true], negate: true)
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": true]))
+        XCTAssertTrue(ConditionEvaluator.evaluate(c, attributes: ["k": false]))
+    }
+
+    func test_type_mismatch_returns_false() {
+        // Numeric op expecting a Number, attribute is a String — handler returns false.
+        let c = cond(attribute: "k", op: .equal, value: ["number": 5])
+        XCTAssertFalse(ConditionEvaluator.evaluate(c, attributes: ["k": "5"]))
+    }
+}
+
+final class PlanAndFeatureFlagEvaluatorTests: XCTestCase {
+
+    private let ruleMatchingTenantA = Rule(
+        conditionLogic: .and,
+        conditions: [
+            Condition(
+                attribute: "frontegg.tenantId",
+                negate: false,
+                op: .inList,
+                value: ["list": ["tenant-A"]]
+            )
+        ],
+        treatment: .true
+    )
+
+    func test_plan_defaultTreatment_applies_when_no_rules_match() {
+        let plan = Plan(defaultTreatment: .false, rules: [ruleMatchingTenantA])
+        XCTAssertEqual(PlanEvaluator.evaluate(plan, attributes: [:]), .false)
+        XCTAssertEqual(
+            PlanEvaluator.evaluate(plan, attributes: ["frontegg.tenantId": "tenant-B"]),
+            .false
+        )
+    }
+
+    func test_plan_rule_overrides_default_when_conditions_match() {
+        let plan = Plan(defaultTreatment: .false, rules: [ruleMatchingTenantA])
+        XCTAssertEqual(
+            PlanEvaluator.evaluate(plan, attributes: ["frontegg.tenantId": "tenant-A"]),
+            .true
+        )
+    }
+
+    func test_plan_with_no_rules_returns_defaultTreatment() {
+        // Exact FR-24821 scenario: defaultTreatment "false", no overriding rules.
+        let plan = Plan(defaultTreatment: .false, rules: nil)
+        XCTAssertEqual(PlanEvaluator.evaluate(plan, attributes: [:]), .false)
+    }
+
+    func test_featureFlag_off_returns_offTreatment_regardless_of_rules() {
+        let flag = FeatureFlag(
+            on: false,
+            offTreatment: .false,
+            defaultTreatment: .true,
+            rules: [ruleMatchingTenantA]
+        )
+        XCTAssertEqual(
+            FeatureFlagEvaluator.evaluate(flag, attributes: ["frontegg.tenantId": "tenant-A"]),
+            .false
+        )
+    }
+
+    func test_featureFlag_on_uses_rules_then_defaultTreatment() {
+        let flag = FeatureFlag(
+            on: true,
+            offTreatment: .false,
+            defaultTreatment: .false,
+            rules: [ruleMatchingTenantA]
+        )
+        XCTAssertEqual(
+            FeatureFlagEvaluator.evaluate(flag, attributes: ["frontegg.tenantId": "tenant-A"]),
+            .true
+        )
+        XCTAssertEqual(FeatureFlagEvaluator.evaluate(flag, attributes: [:]), .false)
+    }
+}
+
+final class IsEntitledToFeatureTests: XCTestCase {
+
+    func test_nil_context_yields_missing_feature() {
+        let result = IsEntitledToFeature.evaluate("anything", context: nil)
+        XCTAssertFalse(result.isEntitled)
+        XCTAssertEqual(result.justification, NotEntitledJustification.MISSING_FEATURE)
+    }
+
+    func test_direct_entitlement_with_NO_EXPIRATION_TIME_wins() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "alpha": FeatureDetail(
+                    planIds: [],
+                    expireTime: FeatureDetail.NO_EXPIRATION_TIME,
+                    linkedPermissions: [],
+                    featureFlag: nil
+                )
+            ],
+            plans: [:],
+            permissions: [:]
+        )
+        let result = IsEntitledToFeature.evaluate("alpha", context: ctx)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+        XCTAssertNil(result.justification)
+    }
+
+    func test_direct_entitlement_reports_BUNDLE_EXPIRED_for_past_time() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "alpha": FeatureDetail(
+                    planIds: [],
+                    expireTime: 86_400_000, // 1970-01-02 — guaranteed past
+                    linkedPermissions: [],
+                    featureFlag: nil
+                )
+            ],
+            plans: [:],
+            permissions: [:]
+        )
+        let result = IsEntitledToFeature.evaluate("alpha", context: ctx)
+        XCTAssertFalse(result.isEntitled)
+        XCTAssertEqual(result.justification, NotEntitledJustification.BUNDLE_EXPIRED)
+    }
+
+    func test_featureFlag_on_with_truthy_defaultTreatment_grants_when_direct_does_not() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "alpha": FeatureDetail(
+                    planIds: [],
+                    expireTime: nil,
+                    linkedPermissions: [],
+                    featureFlag: FeatureFlag(on: true, offTreatment: .false, defaultTreatment: .true, rules: nil)
+                )
+            ],
+            plans: [:],
+            permissions: [:]
+        )
+        let result = IsEntitledToFeature.evaluate("alpha", context: ctx)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+    }
+
+    func test_plan_targeting_evaluator_grants_when_rule_matches_jwt_tenantId() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "sso": FeatureDetail(
+                    planIds: ["plan-1"],
+                    expireTime: nil,
+                    linkedPermissions: [],
+                    featureFlag: nil
+                )
+            ],
+            plans: [
+                "plan-1": Plan(
+                    defaultTreatment: .false,
+                    rules: [
+                        Rule(
+                            conditionLogic: .and,
+                            conditions: [
+                                Condition(
+                                    attribute: "frontegg.tenantId",
+                                    negate: false,
+                                    op: .inList,
+                                    value: ["list": ["tenant-A"]]
+                                )
+                            ],
+                            treatment: .true
+                        )
+                    ]
+                )
+            ],
+            permissions: [:]
+        )
+        let attrs = Attributes(jwt: ["tenantId": "tenant-A"])
+        let result = IsEntitledToFeature.evaluate("sso", context: ctx, attributes: attrs)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+    }
+
+    func test_fr_24821_sso_with_defaultTreatment_false_is_not_entitled() {
+        // The exact customer reproduction from FR-24821 / Yonatan's Slack thread:
+        //
+        // The /user-entitlements response lists "sso" in the features catalog with a
+        // linked plan that has `defaultTreatment: "false"` (and no overriding rules
+        // for the current tenant). Web evaluates this correctly as "not entitled".
+        // Pre-fix the mobile SDK only looked at the features map's keys and reported
+        // isEntitled=true — that's the bug this whole PR closes.
+        let ctx = UserEntitlementsContext(
+            features: [
+                "sso": FeatureDetail(
+                    planIds: ["ID_1"],
+                    expireTime: nil,
+                    linkedPermissions: [],
+                    featureFlag: nil
+                )
+            ],
+            plans: [
+                "ID_1": Plan(defaultTreatment: .false, rules: nil)
+            ],
+            permissions: [:]
+        )
+        let attrs = Attributes(jwt: ["tenantId": "tenant-without-sso"])
+        let result = IsEntitledToFeature.evaluate("sso", context: ctx, attributes: attrs)
+        XCTAssertFalse(result.isEntitled, "\(result)")
+        XCTAssertEqual(result.justification, NotEntitledJustification.MISSING_FEATURE)
+    }
+
+    func test_aggregate_reports_BUNDLE_EXPIRED_if_any_evaluator_hit_expiry() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "alpha": FeatureDetail(
+                    planIds: [],
+                    expireTime: 86_400_000, // expired
+                    linkedPermissions: [],
+                    featureFlag: nil
+                )
+            ],
+            plans: [:],
+            permissions: [:]
+        )
+        let result = IsEntitledToFeature.evaluate("alpha", context: ctx)
+        XCTAssertEqual(result.justification, NotEntitledJustification.BUNDLE_EXPIRED)
+    }
+
+    func test_feature_missing_from_catalog_yields_MISSING_FEATURE() {
+        let ctx = UserEntitlementsContext(features: [:], plans: [:], permissions: [:])
+        let result = IsEntitledToFeature.evaluate("unknown", context: ctx)
+        XCTAssertFalse(result.isEntitled)
+        XCTAssertEqual(result.justification, NotEntitledJustification.MISSING_FEATURE)
+    }
+}
+
+final class IsEntitledToPermissionTests: XCTestCase {
+
+    private let emptyCtx = UserEntitlementsContext(features: [:], plans: [:], permissions: [:])
+
+    func test_nil_context_yields_MISSING_PERMISSION() {
+        let result = IsEntitledToPermission.evaluate("fe.secure.read.users", context: nil)
+        XCTAssertFalse(result.isEntitled)
+        XCTAssertEqual(result.justification, NotEntitledJustification.MISSING_PERMISSION)
+    }
+
+    func test_wildcard_granted_permission_matches_concrete_request() {
+        let ctx = UserEntitlementsContext(
+            features: [:], plans: [:], permissions: ["fe.secure.*": true]
+        )
+        let result = IsEntitledToPermission.evaluate("fe.secure.read.users", context: ctx)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+    }
+
+    func test_wildcard_dot_is_literal_not_regex_any() {
+        // "fe.secure" should NOT match "feXsecure" — dots are escaped.
+        let ctx = UserEntitlementsContext(features: [:], plans: [:], permissions: ["fe.secure": true])
+        let result = IsEntitledToPermission.evaluate("feXsecure", context: ctx)
+        XCTAssertFalse(result.isEntitled, "\(result)")
+    }
+
+    func test_permission_with_no_linked_features_is_entitled_once_granted() {
+        let ctx = UserEntitlementsContext(
+            features: [:], plans: [:], permissions: ["fe.profile.read": true]
+        )
+        let result = IsEntitledToPermission.evaluate("fe.profile.read", context: ctx)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+    }
+
+    func test_permission_linked_to_not_entitled_feature_is_denied() {
+        // Permission is granted by the server but it's gated on the "sso" feature,
+        // which in turn rolls up to a plan with defaultTreatment "false". The
+        // permission should NOT be reported as entitled.
+        let ctx = UserEntitlementsContext(
+            features: [
+                "sso": FeatureDetail(
+                    planIds: ["plan-no-sso"],
+                    expireTime: nil,
+                    linkedPermissions: ["fe.secure.read.samlDefaultRoles"],
+                    featureFlag: nil
+                )
+            ],
+            plans: [
+                "plan-no-sso": Plan(defaultTreatment: .false, rules: nil)
+            ],
+            permissions: ["fe.secure.read.samlDefaultRoles": true]
+        )
+        let result = IsEntitledToPermission.evaluate("fe.secure.read.samlDefaultRoles", context: ctx)
+        XCTAssertFalse(result.isEntitled, "\(result)")
+        XCTAssertEqual(result.justification, NotEntitledJustification.MISSING_FEATURE)
+    }
+
+    func test_permission_linked_to_entitled_feature_passes() {
+        let ctx = UserEntitlementsContext(
+            features: [
+                "alpha": FeatureDetail(
+                    planIds: [],
+                    expireTime: FeatureDetail.NO_EXPIRATION_TIME,
+                    linkedPermissions: ["fe.profile.write"],
+                    featureFlag: nil
+                )
+            ],
+            plans: [:],
+            permissions: ["fe.profile.write": true]
+        )
+        let result = IsEntitledToPermission.evaluate("fe.profile.write", context: ctx)
+        XCTAssertTrue(result.isEntitled, "\(result)")
+    }
+}
+
+final class UserEntitlementsParserTests: XCTestCase {
+
+    private func parse(_ json: String) -> UserEntitlementsContext {
+        let data = json.data(using: .utf8)!
+        let obj = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        return UserEntitlementsParser.parse(obj)
+    }
+
+    func test_FR_24821_minimal_response() {
+        let json = """
+        {
+          "features": {
+            "sso": { "planIds": ["ID_1"], "expireTime": null, "linkedPermissions": [] }
+          },
+          "plans": {
+            "ID_1": { "defaultTreatment": "false" }
+          },
+          "permissions": {}
+        }
+        """
+        let ctx = parse(json)
+        let sso = ctx.features["sso"]
+        XCTAssertNotNil(sso)
+        XCTAssertEqual(sso?.planIds, ["ID_1"])
+        XCTAssertNil(sso?.expireTime, "expireTime explicitly null must remain nil")
+
+        let plan = ctx.plans["ID_1"]
+        XCTAssertNotNil(plan)
+        XCTAssertEqual(plan?.defaultTreatment, .false)
+    }
+
+    func test_expireTime_NO_EXPIRATION_TIME_parses() {
+        let json = """
+        {"features":{"alpha":{"planIds":[],"expireTime":-1,"linkedPermissions":[]}},"plans":{},"permissions":{}}
+        """
+        let ctx = parse(json)
+        XCTAssertEqual(ctx.features["alpha"]?.expireTime, FeatureDetail.NO_EXPIRATION_TIME)
+    }
+
+    func test_permissions_drops_non_boolean_entries() {
+        let json = """
+        {
+          "features": {},
+          "plans": {},
+          "permissions": {
+            "fe.read": true,
+            "fe.write": false,
+            "fe.junk": "not-a-bool"
+          }
+        }
+        """
+        let ctx = parse(json)
+        XCTAssertEqual(ctx.permissions["fe.read"], true)
+        XCTAssertEqual(ctx.permissions["fe.write"], false)
+        XCTAssertNil(ctx.permissions["fe.junk"], "non-boolean entry must drop")
+    }
+
+    func test_rule_with_unknown_operation_is_dropped() {
+        // Forward-compat: server may add operations the SDK doesn't know yet.
+        let json = """
+        {
+          "features": { "alpha": { "planIds": ["p1"], "expireTime": null, "linkedPermissions": [] } },
+          "plans": {
+            "p1": {
+              "defaultTreatment": "false",
+              "rules": [
+                {
+                  "conditionLogic": "and",
+                  "treatment": "true",
+                  "conditions": [
+                    {"attribute":"x","negate":false,"op":"future_op","value":{}}
+                  ]
+                }
+              ]
+            }
+          },
+          "permissions": {}
+        }
+        """
+        let ctx = parse(json)
+        XCTAssertEqual(ctx.plans["p1"]?.rules?.count, 0, "rule with unknown op must drop")
+    }
+
+    func test_feature_flag_with_rules_parses_end_to_end() {
+        let json = """
+        {
+          "features": {
+            "beta": {
+              "planIds": [], "expireTime": null, "linkedPermissions": [],
+              "featureFlag": {
+                "on": true, "offTreatment": "false", "defaultTreatment": "false",
+                "rules": [
+                  {
+                    "conditionLogic": "and", "treatment": "true",
+                    "conditions": [
+                      {"attribute":"frontegg.tenantId","negate":false,"op":"in_list","value":{"list":["tenant-A"]}}
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "plans": {},
+          "permissions": {}
+        }
+        """
+        let ctx = parse(json)
+        let flag = ctx.features["beta"]?.featureFlag
+        XCTAssertEqual(flag?.on, true)
+        XCTAssertEqual(flag?.offTreatment, .false)
+        XCTAssertEqual(flag?.defaultTreatment, .false)
+        let rule = flag?.rules?[0]
+        XCTAssertEqual(rule?.treatment, .true)
+        XCTAssertEqual(rule?.conditions[0].attribute, "frontegg.tenantId")
+        XCTAssertEqual(rule?.conditions[0].op, FronteggOperation.inList)
+    }
+
+    func test_malformed_feature_flag_drops_flag_keeps_feature() {
+        let json = """
+        {
+          "features": {
+            "beta": {
+              "planIds": [], "expireTime": null, "linkedPermissions": [],
+              "featureFlag": {"on": true}
+            }
+          },
+          "plans": {},
+          "permissions": {}
+        }
+        """
+        let ctx = parse(json)
+        XCTAssertNotNil(ctx.features["beta"])
+        XCTAssertNil(ctx.features["beta"]?.featureFlag, "malformed flag must drop, not crash the feature")
+    }
+}

--- a/Tests/FronteggSwiftTests/EntitlementsTests.swift
+++ b/Tests/FronteggSwiftTests/EntitlementsTests.swift
@@ -107,8 +107,19 @@ final class EntitlementsTests: XCTestCase {
     }
 
     func test_load_withValidJson_updatesStateAndReturnsTrue() async {
+        // FR-24821: the verdict is driven by the full UserEntitlementsContext now
+        // (features w/ planIds/expireTime/featureFlag + plans + permissions), NOT
+        // by the legacy featureKeys set. To assert "sso" is entitled, the response
+        // must mark it as directly assigned — `expireTime: -1` (NO_EXPIRATION_TIME)
+        // is the canonical "directly assigned, never expires" sentinel mirrored
+        // from web.
+        //
+        // `test-feature` deliberately has no expireTime/planIds/featureFlag — the
+        // catalog populates featureKeys for backwards compat with host apps that
+        // render counts, but checkFeature("test-feature") correctly reports
+        // MISSING_FEATURE because there's no entitlement path.
         let json = """
-        {"features":{"test-feature":{},"sso":{}},"permissions":{"fe.secure.*":true,"fe.connectivity.*":false}}
+        {"features":{"test-feature":{},"sso":{"expireTime":-1}},"permissions":{"fe.secure.*":true,"fe.connectivity.*":false}}
         """
         let data = json.data(using: .utf8)!
         let response = HTTPURLResponse(url: URL(string: "https://test.example.com/e")!, statusCode: 200, httpVersion: nil, headerFields: nil)!

--- a/demo-application-id/demo-application-id/UserPage.swift
+++ b/demo-application-id/demo-application-id/UserPage.swift
@@ -12,6 +12,10 @@ struct UserPage: View {
     @State private var entitlementUnifiedPermission: Entitlement?
     @State private var entitlementsLoading = false
     @State private var showAdminPortal = false
+    // Active tenant on the most recent entitlements render. See FR-24821 —
+    // without this, the UI shows stale verdicts after switchTenant until the
+    // user manually re-taps "Load entitlements".
+    @State private var lastRenderedTenantId: String?
 
     struct Message: Identifiable {
         let id = UUID()
@@ -33,6 +37,17 @@ struct UserPage: View {
                 .ignoresSafeArea(edges: .bottom),alignment: .bottom)
             .sheet(isPresented: $showAdminPortal) {
                 AdminPortalView()
+            }
+            // Auto-refresh entitlements after switchTenant — see FR-24821.
+            .onChange(of: fronteggAuth.user?.activeTenant.id) { newTenantId in
+                guard let newTenantId = newTenantId else {
+                    lastRenderedTenantId = nil
+                    return
+                }
+                if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
+                    loadEntitlements()
+                }
+                lastRenderedTenantId = newTenantId
             }
         }
     }

--- a/demo-application-id/demo-application-id/UserPage.swift
+++ b/demo-application-id/demo-application-id/UserPage.swift
@@ -45,7 +45,10 @@ struct UserPage: View {
                     return
                 }
                 if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
-                    loadEntitlements()
+                    // forceRefresh: true is REQUIRED — a plain cache read races the
+                    // SDK's clear()+reload during the switch and renders the new
+                    // tenant as not-entitled (FR-24821).
+                    loadEntitlements(forceRefresh: true)
                 }
                 lastRenderedTenantId = newTenantId
             }
@@ -156,14 +159,18 @@ struct UserPage: View {
         .cornerRadius(8)
     }
 
-    private func loadEntitlements() {
+    // forceRefresh MUST be true when called from the tenant-switch `.onChange`
+    // handler (FR-24821): a forceRefresh=false call short-circuits and reads the
+    // verdict during the SDK's cleared-but-not-yet-reloaded window. The button
+    // keeps forceRefresh=false.
+    private func loadEntitlements(forceRefresh: Bool = false) {
         entitlementsLoading = true
         loadSuccess = nil
         entitlementFeature = nil
         entitlementPermission = nil
         entitlementUnifiedFeature = nil
         entitlementUnifiedPermission = nil
-        fronteggAuth.loadEntitlements { success in
+        fronteggAuth.loadEntitlements(forceRefresh: forceRefresh) { success in
             let feature = fronteggAuth.getFeatureEntitlements(featureKey: "sso")
             let unifiedFeature = fronteggAuth.getEntitlements(options: .featureKey("proteins.*"))
             let permission = fronteggAuth.getPermissionEntitlements(permissionKey: "dora.protein.*")

--- a/demo-embedded/demo-embedded/UserPage.swift
+++ b/demo-embedded/demo-embedded/UserPage.swift
@@ -46,7 +46,10 @@ struct UserPage: View {
                     return
                 }
                 if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
-                    loadEntitlements()
+                    // forceRefresh: true is REQUIRED — a plain cache read races the
+                    // SDK's clear()+reload during the switch and renders the new
+                    // tenant as not-entitled (FR-24821).
+                    loadEntitlements(forceRefresh: true)
                 }
                 lastRenderedTenantId = newTenantId
             }
@@ -220,14 +223,18 @@ struct UserPage: View {
         .cornerRadius(8)
     }
 
-    private func loadEntitlements() {
+    // forceRefresh MUST be true when called from the tenant-switch `.onChange`
+    // handler (FR-24821): a forceRefresh=false call short-circuits and reads the
+    // verdict during the SDK's cleared-but-not-yet-reloaded window. The button
+    // keeps forceRefresh=false.
+    private func loadEntitlements(forceRefresh: Bool = false) {
         entitlementsLoading = true
         loadSuccess = nil
         entitlementFeature = nil
         entitlementPermission = nil
         entitlementUnifiedFeature = nil
         entitlementUnifiedPermission = nil
-        fronteggAuth.loadEntitlements { success in
+        fronteggAuth.loadEntitlements(forceRefresh: forceRefresh) { success in
             let feature = fronteggAuth.getFeatureEntitlements(featureKey: "sso")
             let unifiedFeature = fronteggAuth.getEntitlements(options: .featureKey("proteins.*"))
             let permission = fronteggAuth.getPermissionEntitlements(permissionKey: "dora.protein.*")

--- a/demo-embedded/demo-embedded/UserPage.swift
+++ b/demo-embedded/demo-embedded/UserPage.swift
@@ -13,6 +13,10 @@ struct UserPage: View {
     @State private var entitlementUnifiedPermission: Entitlement?
     @State private var entitlementsLoading = false
     @State private var showAdminPortal = false
+    // Active tenant on the most recent entitlements render. See FR-24821 —
+    // without this, the UI shows stale verdicts after switchTenant until the
+    // user manually re-taps "Load entitlements".
+    @State private var lastRenderedTenantId: String?
 
     struct Message: Identifiable {
         let id = UUID()
@@ -34,6 +38,17 @@ struct UserPage: View {
                 .ignoresSafeArea(edges: .bottom),alignment: .bottom)
             .sheet(isPresented: $showAdminPortal) {
                 AdminPortalView()
+            }
+            // Auto-refresh entitlements after switchTenant — see FR-24821.
+            .onChange(of: fronteggAuth.user?.activeTenant.id) { newTenantId in
+                guard let newTenantId = newTenantId else {
+                    lastRenderedTenantId = nil
+                    return
+                }
+                if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
+                    loadEntitlements()
+                }
+                lastRenderedTenantId = newTenantId
             }
         }
     }

--- a/demo-multi-region/demo-multi-region/UserPage.swift
+++ b/demo-multi-region/demo-multi-region/UserPage.swift
@@ -46,7 +46,10 @@ struct UserPage: View {
                     return
                 }
                 if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
-                    loadEntitlements()
+                    // forceRefresh: true is REQUIRED — a plain cache read races the
+                    // SDK's clear()+reload during the switch and renders the new
+                    // tenant as not-entitled (FR-24821).
+                    loadEntitlements(forceRefresh: true)
                 }
                 lastRenderedTenantId = newTenantId
             }
@@ -157,14 +160,18 @@ struct UserPage: View {
         .cornerRadius(8)
     }
 
-    private func loadEntitlements() {
+    // forceRefresh MUST be true when called from the tenant-switch `.onChange`
+    // handler (FR-24821): a forceRefresh=false call short-circuits and reads the
+    // verdict during the SDK's cleared-but-not-yet-reloaded window. The button
+    // keeps forceRefresh=false.
+    private func loadEntitlements(forceRefresh: Bool = false) {
         entitlementsLoading = true
         loadSuccess = nil
         entitlementFeature = nil
         entitlementPermission = nil
         entitlementUnifiedFeature = nil
         entitlementUnifiedPermission = nil
-        fronteggAuth.loadEntitlements { success in
+        fronteggAuth.loadEntitlements(forceRefresh: forceRefresh) { success in
             let feature = fronteggAuth.getFeatureEntitlements(featureKey: "sso")
             let unifiedFeature = fronteggAuth.getEntitlements(options: .featureKey("proteins.*"))
             let permission = fronteggAuth.getPermissionEntitlements(permissionKey: "dora.protein.*")

--- a/demo-multi-region/demo-multi-region/UserPage.swift
+++ b/demo-multi-region/demo-multi-region/UserPage.swift
@@ -12,6 +12,10 @@ struct UserPage: View {
     @State private var entitlementUnifiedPermission: Entitlement?
     @State private var entitlementsLoading = false
     @State private var showAdminPortal = false
+    // Active tenant on the most recent entitlements render. See FR-24821 —
+    // without this, the UI shows stale verdicts after switchTenant until the
+    // user manually re-taps "Load entitlements".
+    @State private var lastRenderedTenantId: String?
 
     struct Message: Identifiable {
         let id = UUID()
@@ -34,6 +38,17 @@ struct UserPage: View {
             .accessibilityIdentifier("UserPageRoot")
             .sheet(isPresented: $showAdminPortal) {
                 AdminPortalView()
+            }
+            // Auto-refresh entitlements after switchTenant — see FR-24821.
+            .onChange(of: fronteggAuth.user?.activeTenant.id) { newTenantId in
+                guard let newTenantId = newTenantId else {
+                    lastRenderedTenantId = nil
+                    return
+                }
+                if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
+                    loadEntitlements()
+                }
+                lastRenderedTenantId = newTenantId
             }
         }
     }

--- a/demo/demo/UserPage.swift
+++ b/demo/demo/UserPage.swift
@@ -12,6 +12,13 @@ struct UserPage: View {
     @State private var entitlementUnifiedPermission: Entitlement?
     @State private var entitlementsLoading = false
     @State private var showAdminPortal = false
+    // Active tenant on the most recent entitlements render. Used by the
+    // `onChange(of: fronteggAuth.user?.activeTenant.id)` watcher to detect
+    // tenant switches and trigger an automatic re-render — without this, the
+    // user has to manually tap "Load entitlements" again after `switchTenant`
+    // to see the new tenant's verdicts (the SDK cache is correct, but the UI
+    // is stale until someone re-calls getFeatureEntitlements). See FR-24821.
+    @State private var lastRenderedTenantId: String?
 
     struct Message: Identifiable {
         let id = UUID()
@@ -33,6 +40,22 @@ struct UserPage: View {
                 .ignoresSafeArea(edges: .bottom),alignment: .bottom)
             .sheet(isPresented: $showAdminPortal) {
                 AdminPortalView()
+            }
+            // Auto-refresh entitlements display on tenant switch. switchTenant
+            // (via setCredentialsInternal → updateStateWithCredentials) already
+            // clears the SDK cache and re-fires loadEntitlements; we just need
+            // to re-call getFeatureEntitlements/getPermissionEntitlements to
+            // refresh the verdict rows. Without this, "Load entitlements" has
+            // to be tapped manually after each switch (FR-24821 QA finding).
+            .onChange(of: fronteggAuth.user?.activeTenant.id) { newTenantId in
+                guard let newTenantId = newTenantId else {
+                    lastRenderedTenantId = nil
+                    return
+                }
+                if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
+                    loadEntitlements()
+                }
+                lastRenderedTenantId = newTenantId
             }
         }
     }

--- a/demo/demo/UserPage.swift
+++ b/demo/demo/UserPage.swift
@@ -53,7 +53,10 @@ struct UserPage: View {
                     return
                 }
                 if lastRenderedTenantId != nil && lastRenderedTenantId != newTenantId {
-                    loadEntitlements()
+                    // forceRefresh: true is REQUIRED — a plain cache read races the
+                    // SDK's clear()+reload during the switch and renders the new
+                    // tenant as not-entitled (FR-24821).
+                    loadEntitlements(forceRefresh: true)
                 }
                 lastRenderedTenantId = newTenantId
             }
@@ -185,14 +188,19 @@ struct UserPage: View {
         .cornerRadius(8)
     }
 
-    private func loadEntitlements() {
+    // forceRefresh MUST be true when called from the tenant-switch `.onChange`
+    // handler: switchTenant clears the cache and kicks off an async reload, and a
+    // forceRefresh=false call would short-circuit and read the verdict during the
+    // cleared-but-not-yet-reloaded window (every feature reads not-entitled —
+    // FR-24821). The "Load entitlements" button keeps forceRefresh=false.
+    private func loadEntitlements(forceRefresh: Bool = false) {
         entitlementsLoading = true
         loadSuccess = nil
         entitlementFeature = nil
         entitlementPermission = nil
         entitlementUnifiedFeature = nil
         entitlementUnifiedPermission = nil
-        fronteggAuth.loadEntitlements { success in
+        fronteggAuth.loadEntitlements(forceRefresh: forceRefresh) { success in
             let feature = fronteggAuth.getFeatureEntitlements(featureKey: "sso")
             let unifiedFeature = fronteggAuth.getEntitlements(options: .featureKey("proteins.*"))
             let permission = fronteggAuth.getPermissionEntitlements(permissionKey: "dora.protein.*")


### PR DESCRIPTION
## Summary

Port of [frontegg/frontegg-android-kotlin#257](https://github.com/frontegg/frontegg-android-kotlin/pull/257) to the Swift SDK. Closes the decision-logic gap behind FR-24821.

The mobile SDK was only checking whether a feature/permission *key* was present in the `/user-entitlements` response — but the response is a **catalog** (features + their linked plans, expiry, feature flags, and per-rule condition graphs), not a list of "what the user has." Web does the full evaluation; mobile didn't. Result: a feature like `sso` linked to a plan with `defaultTreatment: "false"` came back as `isEntitled = true` on mobile even though web (correctly) said the user wasn't entitled.

This PR ports [`@frontegg/entitlements-javascript-commons`](https://www.npmjs.com/package/@frontegg/entitlements-javascript-commons) (the canonical evaluator the React / JS / Next.js SDKs all run on) to Swift.

**Complementary to [#265](https://github.com/frontegg/frontegg-ios-swift/pull/265)** — that PR handles cache invalidation on tenant switch and remains valid. This PR closes a different gap (the decision logic itself).

## Why

Yonatan's reproduction from FR-24821:

```json
{
  "features": {
    "sso": {"planIds": ["ID_1"], "expireTime": null}
  },
  "plans": {
    "ID_1": {"defaultTreatment": "false"}
  }
}
```

Pre-fix mobile saw `"sso"` in `features` → `isEntitled = true`. Web (correctly) follows `sso.planIds[0]` → `plans.ID_1.defaultTreatment` → `"false"` → not entitled.

## What landed

| Layer | Files |
|---|---|
| Models (TS shapes ported 1:1) | `entitlements/UserEntitlementsContext.swift` — `FeatureDetail`, `Plan`, `FeatureFlag`, `Rule`, `Condition`, `Treatment`, `ConditionLogic`, **`FronteggOperation`** (prefix avoids collision with `Foundation.Operation`) |
| Operations matrix | `entitlements/Operations.swift` — string (`in_list`/`starts_with`/`ends_with`/`contains`/`matches`), numeric (`equal`/`gt`/`gte`/`lt`/`lte`/`between`), boolean (`is`), date (`on`/`on_or_after`/`on_or_before`/`between`); sanitizer + handler per op, fails closed on type mismatch |
| Evaluators | `entitlements/Evaluators.swift` — `ConditionEvaluator` → `RuleEvaluator` → `PlanEvaluator` / `FeatureFlagEvaluator` → `IsEntitledToFeature` (direct + flag + plan-targeting chain) → `IsEntitledToPermission` (wildcard match + linked-feature roll-up) |
| Attribute prep | `entitlements/AttributesPreparer.swift` — merges custom + JWT claims with the same `frontegg.` / `jwt.` prefix scheme web uses |
| Permission matching | `entitlements/PermissionMatcher.swift` — anchored wildcard regex with metachar escaping |
| Parser | `entitlements/UserEntitlementsParser.swift` — lenient JSON → context; handles NSNumber/Bool bridging via `CFGetTypeID(n) == CFBooleanGetTypeID()` (Swift's `as? Double` accepts Bools through NSNumber otherwise) |
| Wiring | `services/Entitlements.swift` (parse full context, keep legacy `featureKeys`/`permissionKeys` for backcompat), `auth/FronteggAuth+Entitlements.swift` (decode JWT claims from current access token via the existing `JWTHelper.decode`, thread them + new optional `customAttributes` param through `Attributes` — per Yonatan: attributes "should be in JWT") |

## Backwards compatibility

- Existing host-app code reading `auth.entitlements.state.featureKeys` / `permissionKeys` still works.
- `getFeatureEntitlements(featureKey:)`, `getPermissionEntitlements(permissionKey:)`, `getEntitlements(options:)` get an additional optional `customAttributes` parameter defaulting to `nil` — existing call sites don't need to change.
- `NotEntitledJustification` adds `BUNDLE_EXPIRED` to match web's enum.

## Tests

| Test class | What it covers |
|---|---|
| `ConditionEvaluatorTests` (14) | every operation kind + negate + malformed-payload + type-mismatch + null-attribute |
| `PlanAndFeatureFlagEvaluatorTests` (5) | `defaultTreatment`, rule precedence, flag on/off |
| `IsEntitledToFeatureTests` (8) | direct / flag / plan chain priorities, `BUNDLE_EXPIRED` aggregation, **FR-24821 repro** |
| `IsEntitledToPermissionTests` (6) | wildcard matching, regex-meta escaping, linked-feature roll-up |
| `UserEntitlementsParserTests` (6) | happy path (FR-24821 shape), `expireTime` nils, unknown operations dropped, malformed sub-objects dropped without crashing |

Pre-existing `EntitlementsTests.test_load_withValidJson_updatesStateAndReturnsTrue` updated to use the new `UserEntitlementsContext` path (the old fixture relied on the exact bug this fix corrects).

## Verification

- [x] All 39 new entitlement tests pass
- [x] `xcodebuild -scheme FronteggSwift -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' test` — **732 tests / 0 failures / 18 skipped**
- [ ] Manual repro on iOS demo (Tenant A with SSO → switch to Tenant B without SSO → call `getFeatureEntitlements(featureKey: "sso")` → expect `.isEntitled == false`)

## Related

- [#265](https://github.com/frontegg/frontegg-ios-swift/pull/265) — cache invalidation on tenant switch (complementary, still valid)
- [frontegg-android-kotlin#257](https://github.com/frontegg/frontegg-android-kotlin/pull/257) — the Android sibling of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)