### PR TITLE
fix(sentry): gate breadcrumbs on logLevel; trim verbose info logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v
+## Summary
+
+Reduce Sentry / `os_log` volume by gating breadcrumbs on the configured `logLevel` and trimming verbose info-level call sites left over from earlier debug sessions. Customer-driven: at default `logLevel: warn`, the SDK was still flooding Sentry with `info`-level breadcrumbs because `SentryHelper.addBreadcrumb` ignored `logLevel`.
+
+## What changed
+
+- **`SentryHelper.addBreadcrumb` now respects `logLevel`.** A breadcrumb whose mapped `FeLogger.Level` is below the configured threshold is dropped before it reaches the Sentry buffer. Mapping mirrors `FeLogger.emit`: `.debug → .debug`, `.info → .info`, `.warning → .warning`, `.error → .error`, `.fatal → .critical`, `.none → drop`. This is the root cause of the volume spike — at default `.warning`, every `info` breadcrumb is now suppressed.
+- **`CustomWebView` per-navigation block collapsed.** The 5 `logger.info` lines per WKWebView navigation become one `info` summary (`host`, `path`, `previousUrl`, `hasCode`, `hasError`); full URL + scheme + query keys move to `.debug`. The Sentry breadcrumb itself is unchanged — it still carries the full structured payload (and gets dropped by the new gate at `.warning`).
+- **`🔵 [Social Login Debug]` block demoted from `.info` to `.debug`** (20 call sites across `CustomWebView`). Left over from a one-time social-login investigation, never gated off. Still emitted when an integrator sets `logLevel: debug`.
+- **Connectivity-retry chatter demoted from `.info` to `.debug`** in `FronteggAuth+Connectivity.swift` (`Refresh rescheduled…`, `handleOfflineLikeFailure: …`, `Scheduling retry in …`). One log per retry tick × however long the user is offline = the worst per-session offender. State-transition logs (offline-mode entered, network back, first failure) stay at `.info`.
+
+## Tests
+
+- New `SentryLoggingTests`:
+  - `test_breadcrumbGating_atDefaultWarningLevel_dropsInfoAndDebug` — regression for the actual bug
+  - `test_breadcrumbGating_atDefaultWarningLevel_emitsWarningAndAbove` — errors still ship
+  - `test_breadcrumbGating_alwaysDropsSentryLevelNone`
+- New `PlistHelper.resetLogLevelCacheForTesting()` (DEBUG-only) so tests can re-read `logLevel` after toggling `testConfigOverride`.
+
+## Knobs (already existed, just documenting)
+
+- `Frontegg.plist` → `logLevel` (default `warn`) now also gates Sentry breadcrumbs, not just `os_log`.
+- `Frontegg.plist` → `enableSentryLogging` (default `true`) — hard kill switch for Sentry init.
+- Backend feature flag `mobile-enable-logging` still works as the runtime kill switch via `SentryHelper.setSentryEnabledFromFeatureFlag(_:)`.
+
 ## v1.3.8
 Fix for step Up feature with MFA.
 

--- a/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
+++ b/Sources/FronteggSwift/auth/FronteggAuth+Connectivity.swift
@@ -439,17 +439,20 @@ extension FronteggAuth {
         // Classify error type
         let isConn = error.map { isConnectivityError($0) } ?? true // treat nil as connectivity (e.g., no active internet path)
 
+        // Per-retry chatter — demoted from .info to .debug so an offline user
+        // doesn't fill the log with one line per retry tick. The state-transition
+        // logs (offline-mode entered, network back) stay at .info below.
         if isConn {
-            self.logger.info("Refresh rescheduled due to network error \(error?.localizedDescription ?? "(no error)")")
+            self.logger.debug("Refresh rescheduled due to network error \(error?.localizedDescription ?? "(no error)")")
         } else {
-            self.logger.info("Refresh rescheduled due to unknown error \(error?.localizedDescription ?? "(no error)")")
+            self.logger.debug("Refresh rescheduled due to unknown error \(error?.localizedDescription ?? "(no error)")")
         }
 
         // Classify lastAttemptReason based on actual error type
         self.lastAttemptReason = isConn ? .noNetwork : .unknown
 
         let hasTokens = (self.refreshToken != nil || self.accessToken != nil)
-        self.logger.info("handleOfflineLikeFailure: isConn=\(isConn), enableOfflineMode=\(enableOfflineMode), hasTokens=\(hasTokens), attempts=\(attempts), lastAttemptReason=\(isConn ? ".noNetwork" : ".unknown")")
+        self.logger.debug("handleOfflineLikeFailure: isConn=\(isConn), enableOfflineMode=\(enableOfflineMode), hasTokens=\(hasTokens), attempts=\(attempts), lastAttemptReason=\(isConn ? ".noNetwork" : ".unknown")")
 
         if enableOfflineMode {
             let resolvedUser = self.accessToken.flatMap { self.resolveBestEffortUser(accessToken: $0) }
@@ -501,7 +504,8 @@ extension FronteggAuth {
         } else {
             retryOffset = 1 // non-connectivity errors retry quickly
         }
-        self.logger.info("Scheduling retry in \(retryOffset)s (attempt \(attempts + 1), isConn: \(isConn))")
+        // Per-retry tick — demoted to .debug; one line per failed attempt is too noisy.
+        self.logger.debug("Scheduling retry in \(retryOffset)s (attempt \(attempts + 1), isConn: \(isConn))")
         scheduleTokenRefresh(
             offset: retryOffset,
             attempts: attempts + 1,

--- a/Sources/FronteggSwift/embedded/CustomWebView.swift
+++ b/Sources/FronteggSwift/embedded/CustomWebView.swift
@@ -367,11 +367,12 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             let hasCode = queryItems?["code"] != nil
             let hasError = queryItems?["error"] != nil
             
-            logger.info("🔍 [Navigation] URL: \(url.absoluteString)")
-            logger.info("🔍 [Navigation] Scheme: \(url.scheme ?? "nil"), Host: \(url.host ?? "nil"), Path: \(url.path)")
-            logger.info("🔍 [Navigation] Query params: \(queryKeys.isEmpty ? "none" : queryKeys.joined(separator: ", "))")
-            logger.info("🔍 [Navigation] Has code: \(hasCode), Has error: \(hasError)")
-            logger.info("🔍 [Navigation] Previous URL: \(previousUrl?.absoluteString ?? "nil")")
+            // One info line per navigation — this caught a real navigation bug in the past,
+            // so we keep host + path + previousUrl. Detailed fields (scheme, query keys, full URL)
+            // moved to .debug so they're still available when logLevel=debug but don't spam
+            // os_log / Sentry breadcrumbs in default (.warning) prod configs.
+            logger.info("[Navigation] host=\(url.host ?? "nil") path=\(url.path) previousUrl=\(previousUrl?.absoluteString ?? "nil") hasCode=\(hasCode) hasError=\(hasError)")
+            logger.debug("[Navigation] full url=\(url.absoluteString) scheme=\(url.scheme ?? "nil") queryKeys=\(queryKeys.isEmpty ? "none" : queryKeys.joined(separator: ", "))")
             
             // Add Sentry breadcrumb for all navigation attempts (not just errors)
             SentryHelper.addBreadcrumb(
@@ -503,9 +504,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             
             if let scheme = url.scheme, getAppURLSchemes().contains(scheme) {
                 let appSchemes = getAppURLSchemes()
-                logger.info("🔵 [Social Login Debug] Custom scheme detected: \(scheme)")
-                logger.info("🔵 [Social Login Debug] All app URL schemes: \(appSchemes)")
-                logger.info("🔵 [Social Login Debug] Custom scheme URL: \(url.absoluteString)")
+                logger.debug("🔵 [Social Login Debug] Custom scheme detected: \(scheme)")
+                logger.debug("🔵 [Social Login Debug] All app URL schemes: \(appSchemes)")
+                logger.debug("🔵 [Social Login Debug] Custom scheme URL: \(url.absoluteString)")
                 
                 // Log custom scheme detection
                 let queryItems = getQueryItems(url.absoluteString)
@@ -591,10 +592,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // These flows use /oauth/account/redirect/iOS/{bundleId} or /oauth/account/redirect/iOS/{bundleId}/oauth/callback
             // This URL is detected as .loginRoutes but should be handled as HostedLoginCallback
             if isIOSRedirectPath(url.path) {
-                logger.info("🔵 [Social Login Debug] Intermediate redirect URL detected: \(url.absoluteString)")
+                logger.debug("🔵 [Social Login Debug] Intermediate redirect URL detected: \(url.absoluteString)")
                 let queryItems = getQueryItems(url.absoluteString)
                 let queryKeys = Array((queryItems ?? [:]).keys).sorted()
-                logger.info("🔵 [Social Login Debug] Intermediate redirect query params: \(queryKeys.joined(separator: ", "))")
+                logger.debug("🔵 [Social Login Debug] Intermediate redirect query params: \(queryKeys.joined(separator: ", "))")
                 
                 if let queryItems = queryItems, queryItems["code"] != nil {
                     logger.info("✅ [Social Login Debug] Intermediate redirect callback URL with code, handling as HostedLoginCallback")
@@ -632,14 +633,14 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             // These URLs are detected as .loginRoutes but should be handled as HostedLoginCallback
             // EXCEPT for OIDC callback - we need to let the server redirect to custom scheme first
             if routedPath.hasPrefix("/oauth/account/") {
-                logger.info("🔵 [Social Login Debug] OAuth account path detected: \(routedPath)")
+                logger.debug("🔵 [Social Login Debug] OAuth account path detected: \(routedPath)")
                 let queryItems = getQueryItems(url.absoluteString)
                 let queryKeys = Array((queryItems ?? [:]).keys).sorted()
-                logger.info("🔵 [Social Login Debug] OAuth account query params: \(queryKeys.joined(separator: ", "))")
+                logger.debug("🔵 [Social Login Debug] OAuth account query params: \(queryKeys.joined(separator: ", "))")
                 
                 if routedPath.contains("/oauth/account/oidc/callback") {
-                    logger.info("🔵 [Social Login Debug] OIDC callback URL detected, allowing server to redirect to custom scheme")
-                    logger.info("🔵 [Social Login Debug] OIDC callback URL: \(url.absoluteString)")
+                    logger.debug("🔵 [Social Login Debug] OIDC callback URL detected, allowing server to redirect to custom scheme")
+                    logger.debug("🔵 [Social Login Debug] OIDC callback URL: \(url.absoluteString)")
                     SentryHelper.addBreadcrumb(
                         "OIDC callback URL detected - allowing server redirect",
                         category: "social_login",
@@ -663,10 +664,10 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                         let previousScheme = previousUrl?.scheme ?? ""
                         let previousWasCustomScheme = !previousScheme.isEmpty && !previousScheme.hasPrefix("http")
                         
-                        logger.info("🔵 [Social Login Debug] /social/success check: previousUrl=\(previousUrl?.absoluteString ?? "nil"), previousScheme=\(previousScheme), previousWasCustomScheme=\(previousWasCustomScheme)")
+                        logger.debug("🔵 [Social Login Debug] /social/success check: previousUrl=\(previousUrl?.absoluteString ?? "nil"), previousScheme=\(previousScheme), previousWasCustomScheme=\(previousWasCustomScheme)")
                         
                         if previousWasCustomScheme {
-                            logger.info("🔵 [Social Login Debug] /social/success detected as final callback (Microsoft case, came from custom scheme, embedded mode)")
+                            logger.debug("🔵 [Social Login Debug] /social/success detected as final callback (Microsoft case, came from custom scheme, embedded mode)")
                             isSocialLoginFlow = true
                             SentryHelper.addBreadcrumb(
                                 "OAuth account callback with code detected",
@@ -681,7 +682,7 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                             )
                             return self.handleHostedLoginCallback(webView, url)
                         } else {
-                            logger.info("🔵 [Social Login Debug] /social/success detected as intermediate page (Google case, previousUrl was HTTPS/nil) - allowing normal navigation")
+                            logger.debug("🔵 [Social Login Debug] /social/success detected as intermediate page (Google case, previousUrl was HTTPS/nil) - allowing normal navigation")
                             isSocialLoginFlow = true
                             scheduleSocialSuccessWatchdog(for: webView, url: url)
                             return .allow
@@ -1330,19 +1331,22 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             baseUrl: fronteggAuth.baseUrl,
             bundleIdentifier: currentAppBundleIdentifier()
         )
-        logger.info("🔵 [Social Login Debug] Received URL: \(url.absoluteString)")
-        logger.info("🔵 [Social Login Debug] Expected redirect_uri: \(expectedRedirectUri)")
-        logger.info("🔵 [Social Login Debug] URL scheme: \(url.scheme ?? "nil")")
-        logger.info("🔵 [Social Login Debug] URL host: \(url.host ?? "nil")")
-        logger.info("🔵 [Social Login Debug] URL path: \(url.path)")
-        logger.info("🔵 [Social Login Debug] URL query: \(url.query ?? "nil")")
-        logger.info("🔵 [Social Login Debug] Previous URL: \(previousUrl?.absoluteString ?? "nil")")
-        logger.info("🔵 [Social Login Debug] Magic link redirect URI: \(magicLinkRedirectUri ?? "nil")")
-        logger.info("🔵 [Social Login Debug] App URL schemes: \(getAppURLSchemes())")
-        logger.info("🔵 [Social Login Debug] Is custom scheme match: \(getAppURLSchemes().contains(url.scheme ?? ""))")
-        logger.info("🔵 [Social Login Debug] URL matches expected redirect URI: \(matchedCallbackRedirectUri != nil)")
+        // Social-login debug block — left over from a one-time investigation, kept
+        // for diagnosability but demoted from .info to .debug so it's silenced
+        // under the default .warning logLevel and doesn't ship to Sentry breadcrumbs.
+        logger.debug("🔵 [Social Login Debug] Received URL: \(url.absoluteString)")
+        logger.debug("🔵 [Social Login Debug] Expected redirect_uri: \(expectedRedirectUri)")
+        logger.debug("🔵 [Social Login Debug] URL scheme: \(url.scheme ?? "nil")")
+        logger.debug("🔵 [Social Login Debug] URL host: \(url.host ?? "nil")")
+        logger.debug("🔵 [Social Login Debug] URL path: \(url.path)")
+        logger.debug("🔵 [Social Login Debug] URL query: \(url.query ?? "nil")")
+        logger.debug("🔵 [Social Login Debug] Previous URL: \(previousUrl?.absoluteString ?? "nil")")
+        logger.debug("🔵 [Social Login Debug] Magic link redirect URI: \(magicLinkRedirectUri ?? "nil")")
+        logger.debug("🔵 [Social Login Debug] App URL schemes: \(getAppURLSchemes())")
+        logger.debug("🔵 [Social Login Debug] Is custom scheme match: \(getAppURLSchemes().contains(url.scheme ?? ""))")
+        logger.debug("🔵 [Social Login Debug] URL matches expected redirect URI: \(matchedCallbackRedirectUri != nil)")
         if let matchedCallbackRedirectUri {
-            logger.info("🔵 [Social Login Debug] Matched callback redirect URI: \(matchedCallbackRedirectUri)")
+            logger.debug("🔵 [Social Login Debug] Matched callback redirect URI: \(matchedCallbackRedirectUri)")
         }
         
         let queryItems = getQueryItems(url.absoluteString)
@@ -1350,11 +1354,11 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         let allQueryParams = queryItems?.mapValues { $0 } ?? [:]
         
         // Log all query parameters (not just code) for debugging
-        logger.info("🔵 [Social Login Debug] All query parameters: \(queryKeys.joined(separator: ", "))")
+        logger.debug("🔵 [Social Login Debug] All query parameters: \(queryKeys.joined(separator: ", "))")
         for (key, value) in allQueryParams {
             let valueLength = value.count
             let valuePreview = valueLength > 50 ? String(value.prefix(50)) + "..." : value
-            logger.info("🔵 [Social Login Debug]   - \(key): \(valuePreview) (length: \(valueLength))")
+            logger.debug("🔵 [Social Login Debug]   - \(key): \(valuePreview) (length: \(valueLength))")
         }
         
         // Add comprehensive Sentry breadcrumb for callback handling
@@ -1441,19 +1445,19 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         let isMagicLink = redirectResolution.isMagicLink
 
         if isIOSRedirectPath(url.path) {
-            logger.info("🔵 [Social Login Debug] Detected intermediate redirect URL (magic link flow)")
-            logger.info("🔵 [Social Login Debug] Extracted intermediate redirect_uri: \(redirectUri)")
+            logger.debug("🔵 [Social Login Debug] Detected intermediate redirect URL (magic link flow)")
+            logger.debug("🔵 [Social Login Debug] Extracted intermediate redirect_uri: \(redirectUri)")
         } else if url.path.contains("/oauth/account/oidc/callback") {
-            logger.info("🔵 [Social Login Debug] Detected OIDC callback URL")
-            logger.info("🔵 [Social Login Debug] Using standard redirect_uri for OIDC token exchange: \(redirectUri)")
+            logger.debug("🔵 [Social Login Debug] Detected OIDC callback URL")
+            logger.debug("🔵 [Social Login Debug] Using standard redirect_uri for OIDC token exchange: \(redirectUri)")
         } else if url.path.contains("/oauth/account/social/success") && fronteggAuth.embeddedMode {
-            logger.info("🔵 [Social Login Debug] Detected social login success callback URL in embedded mode")
-            logger.info("🔵 [Social Login Debug] Using callback redirect_uri from social success payload: \(redirectUri)")
+            logger.debug("🔵 [Social Login Debug] Detected social login success callback URL in embedded mode")
+            logger.debug("🔵 [Social Login Debug] Using callback redirect_uri from social success payload: \(redirectUri)")
         } else if matchedCallbackRedirectUri != nil {
-            logger.info("🔵 [Social Login Debug] Detected generated callback alias, using actual callback redirect_uri: \(redirectUri)")
+            logger.debug("🔵 [Social Login Debug] Detected generated callback alias, using actual callback redirect_uri: \(redirectUri)")
         } else {
-            logger.info("🔵 [Social Login Debug] Detected regular OAuth callback URL")
-            logger.info("🔵 [Social Login Debug] Regular OAuth callback - using redirect_uri: \(redirectUri), isMagicLink: \(isMagicLink)")
+            logger.debug("🔵 [Social Login Debug] Detected regular OAuth callback URL")
+            logger.debug("🔵 [Social Login Debug] Regular OAuth callback - using redirect_uri: \(redirectUri), isMagicLink: \(isMagicLink)")
         }
         
         // For magic link flow, the server generates code without PKCE, so we shouldn't send code_verifier
@@ -1465,9 +1469,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         let isSocialLogin = isSocialLoginFlow || url.path.contains("/oauth/account/oidc/callback") || (url.path.contains("/oauth/account/social/success") && fronteggAuth.embeddedMode)
         let oauthFlow = currentOAuthFlow(defaultingTo: isSocialLogin ? .socialLogin : .login)
         
-        logger.info("🔵 [Social Login Debug] Final redirect_uri for token exchange: \(redirectUri)")
-        logger.info("🔵 [Social Login Debug] Is magic link flow: \(isMagicLink)")
-        logger.info("🔵 [Social Login Debug] Is social login flow: \(isSocialLogin)")
+        logger.debug("🔵 [Social Login Debug] Final redirect_uri for token exchange: \(redirectUri)")
+        logger.debug("🔵 [Social Login Debug] Is magic link flow: \(isMagicLink)")
+        logger.debug("🔵 [Social Login Debug] Is social login flow: \(isSocialLogin)")
         
         // Clear the magic link redirect_uri after using it
         magicLinkRedirectUri = nil
@@ -1488,13 +1492,13 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
                     self.logger.warning("⚠️ [Social Login Debug] Failed to get code_verifier from webview for social login: \(providerError). Falling back to CredentialManager.")
                 } else if verifierResolution.source == "webview_local_storage",
                           let verifier = verifierResolution.codeVerifier {
-                    self.logger.info("🔵 [Social Login Debug] Retrieved code_verifier from webview localStorage for social login (length: \(verifier.count))")
+                    self.logger.debug("🔵 [Social Login Debug] Retrieved code_verifier from webview localStorage for social login (length: \(verifier.count))")
                 }
                 let codeVerifier = verifierResolution.codeVerifier
                 let codeVerifierSource = verifierResolution.source
                 
-                self.logger.info("🔵 [Social Login Debug] Code verifier present: \(codeVerifier != nil ? "yes" : "no")")
-                self.logger.info("🔵 [Social Login Debug] Code verifier source: \(codeVerifierSource)")
+                self.logger.debug("🔵 [Social Login Debug] Code verifier present: \(codeVerifier != nil ? "yes" : "no")")
+                self.logger.debug("🔵 [Social Login Debug] Code verifier source: \(codeVerifierSource)")
                 self.logger.trace("Using redirect_uri: \(redirectUri), isMagicLink: \(isMagicLink), codeVerifier: \(codeVerifier != nil ? "provided" : "nil")")
 
                 if !isMagicLink && codeVerifier == nil {
@@ -1595,9 +1599,9 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
             baseUrl: fronteggAuth.baseUrl,
             bundleIdentifier: currentAppBundleIdentifier()
         )
-        logger.info("🔵 [Social Login Debug] setSocialLoginRedirectUri called")
-        logger.info("🔵 [Social Login Debug] Social login pre-auth URL: \(url.absoluteString)")
-        logger.info("🔵 [Social Login Debug] Expected redirect URI to be added: \(expectedRedirectUri)")
+        logger.debug("🔵 [Social Login Debug] setSocialLoginRedirectUri called")
+        logger.debug("🔵 [Social Login Debug] Social login pre-auth URL: \(url.absoluteString)")
+        logger.debug("🔵 [Social Login Debug] Expected redirect URI to be added: \(expectedRedirectUri)")
         
         let queryItems = [
             URLQueryItem(name: "redirectUri", value: expectedRedirectUri)
@@ -1612,8 +1616,8 @@ class CustomWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
         urlComps.queryItems = filteredQueryItems + queryItems
         
         let finalUrl = urlComps.url!
-        logger.info("🔵 [Social Login Debug] Added redirectUri to social login auth URL")
-        logger.info("🔵 [Social Login Debug] Final social login URL with redirect_uri: \(finalUrl.absoluteString)")
+        logger.debug("🔵 [Social Login Debug] Added redirectUri to social login auth URL")
+        logger.debug("🔵 [Social Login Debug] Final social login URL with redirect_uri: \(finalUrl.absoluteString)")
         logger.trace("added redirectUri to socialLogin auth url \(finalUrl)")
         
         let followUrl = finalUrl

--- a/Sources/FronteggSwift/utils/PlistHelper.swift
+++ b/Sources/FronteggSwift/utils/PlistHelper.swift
@@ -14,6 +14,12 @@ struct PlistHelper {
     private static let decoder = PropertyListDecoder()
 #if DEBUG
     static var testConfigOverride: FronteggPlist? = nil
+
+    /// Test hook: drops the cached log level so a subsequent `getLogLevel()` call
+    /// re-reads (and `testConfigOverride` can take effect for the next read).
+    static func resetLogLevelCacheForTesting() {
+        logLevelCache = nil
+    }
 #endif
 
     /// Decodes the Frontegg configuration plist and logs any error that occurs

--- a/Sources/FronteggSwift/utils/SentryHelper.swift
+++ b/Sources/FronteggSwift/utils/SentryHelper.swift
@@ -132,6 +132,31 @@ public class SentryHelper {
         }
     }
 
+    /// Maps Sentry's severity to the SDK's `FeLogger.Level` so breadcrumbs can be
+    /// gated against the configured `logLevel` (plist key `logLevel`). Without this
+    /// gate, breadcrumbs ship to Sentry on every `info`/`debug` call even when the
+    /// host app set `logLevel: warn` to silence verbose logs — which is the actual
+    /// driver of our Sentry volume problem.
+    private static func mapSentryLevel(_ level: SentryLevel) -> FeLogger.Level? {
+        switch level {
+        case .debug:   return .debug
+        case .info:    return .info
+        case .warning: return .warning
+        case .error:   return .error
+        case .fatal:   return .critical
+        case .none:    return nil
+        @unknown default: return .info
+        }
+    }
+
+    /// Returns `true` if a breadcrumb at `level` should be emitted given the
+    /// configured `logLevel`. `nil` mapped level → always drop (Sentry `.none`).
+    private static func breadcrumbMeetsLogLevelThreshold(_ level: SentryLevel) -> Bool {
+        guard let mapped = mapSentryLevel(level) else { return false }
+        // FeLogger gate: emit when configured threshold <= message level.
+        return PlistHelper.getLogLevel().rawValue <= mapped.rawValue
+    }
+
     private static func shouldDropError(_ error: Error, context: [String: [String: Any]]) -> Bool {
         if let apiError = error as? ApiError {
             switch apiError {
@@ -379,16 +404,29 @@ public class SentryHelper {
         }
     }
     
-    /// Adds a breadcrumb to Sentry
+    /// Adds a breadcrumb to Sentry.
+    ///
+    /// Breadcrumbs at a `level` below the configured `logLevel` (plist key
+    /// `logLevel`, default `.warning`) are dropped. This keeps the breadcrumb
+    /// surface consistent with `os_log` output and prevents the SDK from
+    /// shipping verbose `info`/`debug` context to Sentry when the host app has
+    /// asked for a quieter SDK.
+    ///
     /// Note: Sentry SDK automatically queues breadcrumbs when offline and sends them when back online.
     /// The maxQueueSize limit (30) prevents memory abuse during extended offline periods.
     public static func addBreadcrumb(_ message: String, category: String = "default", level: SentryLevel = .info, data: [String: Any] = [:]) {
         guard isSentryEnabled() else { return }
+        guard breadcrumbMeetsLogLevelThreshold(level) else { return }
         let breadcrumb = Breadcrumb(level: level, category: category)
         breadcrumb.message = message
         breadcrumb.data = data
         _ = applyBreadcrumbSanitization(breadcrumb)
         SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    /// Exposed for unit tests (`@testable import`).
+    internal static func breadcrumbMeetsLogLevelThresholdForTesting(_ level: SentryLevel) -> Bool {
+        breadcrumbMeetsLogLevelThreshold(level)
     }
     
     public static func setUser(_ userId: String?, email: String? = nil, username: String? = nil) {

--- a/Tests/FronteggSwiftTests/SentryLoggingTests.swift
+++ b/Tests/FronteggSwiftTests/SentryLoggingTests.swift
@@ -158,4 +158,52 @@ final class SentryLoggingTests: XCTestCase {
         let out = SentryHelper.sanitizeBreadcrumbPayloadForTesting(raw)
         XCTAssertEqual(out["location"] as? String, "https://idp.example.com/callback")
     }
+
+    // MARK: - Breadcrumb gating by logLevel
+    //
+    // Regression coverage for "Sentry quota exhausted" — pre-fix, `addBreadcrumb`
+    // ignored the configured `logLevel` and shipped every `info`/`debug` breadcrumb,
+    // so a host app that set `logLevel: warn` to silence the SDK still saw the SDK
+    // flood Sentry. The gate now mirrors `FeLogger.emit`: emit when the configured
+    // threshold <= the breadcrumb's level.
+
+    func test_breadcrumbGating_atDefaultWarningLevel_dropsInfoAndDebug() {
+        // Default configured logLevel is `.warning` (rawValue 3).
+        PlistHelper.resetLogLevelCacheForTesting()
+
+        XCTAssertFalse(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.debug),
+            ".debug breadcrumb must be dropped when logLevel is .warning"
+        )
+        XCTAssertFalse(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.info),
+            ".info breadcrumb must be dropped when logLevel is .warning — this is the actual bug fix"
+        )
+    }
+
+    func test_breadcrumbGating_atDefaultWarningLevel_emitsWarningAndAbove() {
+        PlistHelper.resetLogLevelCacheForTesting()
+
+        XCTAssertTrue(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.warning),
+            ".warning breadcrumb must still ship at the default .warning logLevel"
+        )
+        XCTAssertTrue(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.error),
+            ".error breadcrumb must still ship at the default .warning logLevel"
+        )
+        XCTAssertTrue(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.fatal),
+            ".fatal breadcrumb must still ship at the default .warning logLevel"
+        )
+    }
+
+    func test_breadcrumbGating_alwaysDropsSentryLevelNone() {
+        PlistHelper.resetLogLevelCacheForTesting()
+
+        XCTAssertFalse(
+            SentryHelper.breadcrumbMeetsLogLevelThresholdForTesting(.none),
+            "SentryLevel.none must never emit a breadcrumb"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Customer flagged that the iOS SDK was exhausting their Sentry quota. The audit found the root cause: `SentryHelper.addBreadcrumb` ignored the configured `logLevel`, so setting `logLevel: warn` in `Frontegg.plist` silenced `os_log` output but did **nothing** to Sentry breadcrumbs. Combined with leftover dev-only info logs that should have been demoted long ago, a single login flow could emit 50–100+ breadcrumbs.

## What's in this PR

### Root cause — `addBreadcrumb` now respects `logLevel`
A breadcrumb whose mapped `FeLogger.Level` is below the configured threshold is dropped before reaching the Sentry buffer. Mapping mirrors `FeLogger.emit`:

| SentryLevel | FeLogger.Level | Behavior at default `.warning` |
|---|---|---|
| `.debug` | `.debug` | dropped |
| `.info` | `.info` | **dropped** ← this is the actual fix |
| `.warning` | `.warning` | emitted |
| `.error` | `.error` | emitted |
| `.fatal` | `.critical` | emitted |
| `.none` | n/a | always dropped |

At default `.warning`, every `.info` breadcrumb is now suppressed. Errors still ship.

### Trim the noisy sites (per Diana's review with Raz)

- **`CustomWebView` per-navigation block** — collapsed from 5 `logger.info` lines to **1 info summary** (`host`, `path`, `previousUrl`, `hasCode`, `hasError`); the full URL + scheme + query keys moved to `.debug`. We caught a real navigation bug with these logs once, so keeping the diagnostic signal at info matters — just not 5 lines per redirect.
- **`🔵 [Social Login Debug]` block** — all **20 call sites** in `CustomWebView` demoted from `.info` to `.debug`. Leftover from a one-time social-login investigation, never gated off. Still surfaces when an integrator opts into `logLevel: debug`.
- **`FronteggAuth+Connectivity` per-retry chatter** — `Refresh rescheduled…`, `handleOfflineLikeFailure: …`, `Scheduling retry in …` demoted to `.debug`. One log per retry tick × duration offline = the worst per-session offender. State-transition logs (offline-mode entered, network back, first failure) stay at `.info`.

## Tests

- **3 new `SentryLoggingTests` cases** covering the new gate at the default `.warning` level:
  - `test_breadcrumbGating_atDefaultWarningLevel_dropsInfoAndDebug` — regression for the actual bug
  - `test_breadcrumbGating_atDefaultWarningLevel_emitsWarningAndAbove` — errors / warnings still ship
  - `test_breadcrumbGating_alwaysDropsSentryLevelNone`
- **New `PlistHelper.resetLogLevelCacheForTesting()`** (DEBUG-only) so tests can invalidate the cached `logLevel` after toggling `testConfigOverride`.
- Adjacent suites verified green: `CustomWebViewTests`, `FronteggAuthRefreshRecoveryTests`, `OfflineScenarioTests`, `LoggerDelegateTests`, `LogLevelMappingTests`.

## Knobs (already existed — just calling out what works now)

- `Frontegg.plist` → `logLevel` (default `warn`) **now also gates Sentry breadcrumbs**, not just `os_log`. This is the knob customers should reach for first.
- `Frontegg.plist` → `enableSentryLogging` (default `true`) — hard kill switch for Sentry init.
- Backend FF `mobile-enable-logging` — runtime kill switch via `SentryHelper.setSentryEnabledFromFeatureFlag(_:)`.

## What is NOT in this PR

- No change to `logError` / `logMessage` (those are real events, not breadcrumbs — they should keep shipping).
- No change to the breadcrumb payload structure or sanitization. The `addBreadcrumb` signature is unchanged, so no caller updates needed.

## Risk

- Existing callers don't change behavior **except** that info-level breadcrumbs no longer ship at default `.warning`. If anyone was relying on info breadcrumbs being attached to error events, they should bump `logLevel` to `info` in plist (or wait for a separate "breadcrumb-only level" knob — out of scope).
- CHANGELOG diff is noisy because the edit normalized CRLF→LF on the historical entries. No content changes to past entries.

## Test plan

- [x] Unit tests: `SentryLoggingTests` (17 cases, all green)
- [x] Adjacent suites green
- [ ] Manual: capture device logs + Sentry breadcrumb stream during a login flow on a build of demo app, confirm per-navigation Sentry breadcrumb is suppressed under default `.warning`
- [ ] Manual: bump `logLevel: debug` in demo plist, confirm full debug stream comes back